### PR TITLE
Legendre functions

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -31,5 +31,6 @@ unsafe extern "C" {
     pub fn math_legendre_p(l: c_int, x: f64) -> f64;
     pub fn math_legendre_p_assoc(l: c_int, m: c_int, x: f64) -> f64;
     pub fn math_legendre_p_prime(l: c_int, x: f64) -> f64;
+    pub fn math_legendre_p_zeros(l: c_int, out: *mut f64);
     pub fn math_legendre_q(l: c_uint, x: f64) -> f64;
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,9 +1,9 @@
 //! Raw FFI declarations for cpp/wrapper.h
 
-use core::ffi::c_uint;
+use core::ffi::{c_int, c_uint};
 
 unsafe extern "C" {
-    // <boost/math/special_functions/bessel.hpp>
+    // boost/math/special_functions/bessel.hpp
     pub fn math_cyl_bessel_j(nu: f64, x: f64) -> f64;
     pub fn math_cyl_neumann(nu: f64, x: f64) -> f64;
     pub fn math_cyl_bessel_i(nu: f64, x: f64) -> f64;
@@ -11,19 +11,25 @@ unsafe extern "C" {
     pub fn math_sph_bessel(n: c_uint, x: f64) -> f64;
     pub fn math_sph_neumann(n: c_uint, x: f64) -> f64;
 
-    // <boost/math/special_functions/beta.hpp>
+    // boost/math/special_functions/beta.hpp
     pub fn math_beta(a: f64, b: f64) -> f64;
 
-    // <boost/math/special_functions/digamma.hpp>
+    // boost/math/special_functions/digamma.hpp
     pub fn math_digamma(x: f64) -> f64;
 
-    // <boost/math/special_functions/erf.hpp>
+    // boost/math/special_functions/erf.hpp
     pub fn math_erf(x: f64) -> f64;
     pub fn math_erfc(x: f64) -> f64;
 
-    // <boost/math/special_functions/gamma.hpp>
+    // boost/math/special_functions/gamma.hpp
     pub fn math_tgamma(x: f64) -> f64;
     pub fn math_lgamma(x: f64) -> f64;
     pub fn math_gamma_p(a: f64, x: f64) -> f64;
     pub fn math_gamma_q(a: f64, x: f64) -> f64;
+
+    // boost/math/special_functions/legendre.hpp
+    pub fn math_legendre_p(l: c_int, x: f64) -> f64;
+    pub fn math_legendre_p_assoc(l: c_int, m: c_int, x: f64) -> f64;
+    pub fn math_legendre_p_prime(l: c_int, x: f64) -> f64;
+    pub fn math_legendre_q(l: c_uint, x: f64) -> f64;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,7 @@
 #[macro_use]
 extern crate approx;
 
+extern crate alloc;
+
 mod ffi;
 pub mod math;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -7,3 +7,4 @@ pub use special_functions::beta::*;
 pub use special_functions::digamma::*;
 pub use special_functions::erf::*;
 pub use special_functions::gamma::*;
+pub use special_functions::legendre::*;

--- a/src/math/special_functions/legendre.rs
+++ b/src/math/special_functions/legendre.rs
@@ -1,0 +1,91 @@
+//! boost/math/special_functions/legendre.hpp
+//!
+//! # TODO:
+//! - `double legendre_next(unsigned l, double x, double Pl, double Plm1)`
+//! - `double legendre_next(unsigned l, unsigned m, double x, double Pl, double Plm1)`
+//! - `std::vector<T> legendre_p_zeros(int l)`
+
+use crate::ffi;
+use core::ffi::{c_int, c_uint};
+
+/// Legendre Polynomial of the 1st kind *P<sub>l</sub>(x)* on *[-1, 1]*
+///
+/// Corresponds to `boost::math::legendre_p(l, x)`.
+///
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
+pub fn legendre_p(l: i32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_p(l as c_int, x) }
+}
+
+/// Associated Legendre Polynomial of the 1st kind *P<sub>l</sub><sup>m</sup>(x)* on *[-1, 1]*
+///
+/// Corresponds to `boost::math::legendre_p(l, m, x)`.
+///
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
+pub fn legendre_p_assoc(l: i32, m: i32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_p_assoc(l as c_int, m as c_int, x) }
+}
+
+/// Derivative of [`legendre_p`] with respect to `x`; *P'<sub>l</sub>(x)*
+///
+/// Corresponds to `boost::math::legendre_p_prime(l, x)`.
+///
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
+pub fn legendre_p_prime(l: i32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_p_prime(l as c_int, x) }
+}
+
+/// Legendre Polynomial of the 2nd kind *Q<sub>l</sub>(x)* on *[-1, 1]*
+///
+/// Corresponds to `boost::math::legendre_q(l, x)`.
+///
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
+pub fn legendre_q(l: u32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_q(l as c_uint, x) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ATOL: f64 = f64::EPSILON;
+    const SQRT_3: f64 = 1.732_050_807_568_877_2;
+    const LN_3: f64 = 1.098_612_288_668_109_8;
+
+    #[test]
+    fn test_legendre_p() {
+        assert_eq!(legendre_p(0, 0.5), 1.0);
+        assert_eq!(legendre_p(-1, 0.5), 1.0);
+        assert_eq!(legendre_p(1, 0.5), 0.5);
+        assert_eq!(legendre_p(-2, 0.5), 0.5);
+        assert_eq!(legendre_p(2, 0.5), -0.125);
+        assert_eq!(legendre_p(-3, 0.5), -0.125);
+    }
+
+    #[test]
+    fn test_legendre_p_assoc() {
+        assert_eq!(legendre_p_assoc(0, 0, 0.5), 1.0);
+        assert_eq!(legendre_p_assoc(1, 0, 0.5), 0.5);
+        assert_eq!(legendre_p_assoc(2, 0, 0.5), -0.125);
+        assert_eq!(legendre_p_assoc(0, 1, 0.5), 0.0);
+        assert_abs_diff_eq!(legendre_p_assoc(1, 1, 0.5), -0.5 * SQRT_3, epsilon = ATOL);
+        assert_abs_diff_eq!(legendre_p_assoc(2, 1, 0.5), -0.75 * SQRT_3, epsilon = ATOL);
+    }
+
+    #[test]
+    fn test_legendre_p_prime() {
+        assert_eq!(legendre_p_prime(0, 0.5), 0.0);
+        assert_eq!(legendre_p_prime(-1, 0.5), 0.0);
+        assert_eq!(legendre_p_prime(1, 0.5), 1.0);
+        assert_eq!(legendre_p_prime(-2, 0.5), 1.0);
+        assert_eq!(legendre_p_prime(2, 0.5), 1.5);
+        assert_eq!(legendre_p_prime(-3, 0.5), 1.5);
+    }
+
+    #[test]
+    fn test_legendre_q() {
+        assert_abs_diff_eq!(legendre_q(0, 0.5), 0.5 * LN_3, epsilon = ATOL);
+        assert_abs_diff_eq!(legendre_q(1, 0.5), 0.25 * LN_3 - 1.0, epsilon = ATOL);
+        assert_abs_diff_eq!(legendre_q(2, 0.5), -0.0625 * LN_3 - 0.75, epsilon = ATOL);
+    }
+}

--- a/src/math/special_functions/mod.rs
+++ b/src/math/special_functions/mod.rs
@@ -3,3 +3,4 @@ pub mod beta;
 pub mod digamma;
 pub mod erf;
 pub mod gamma;
+pub mod legendre;

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -52,10 +52,15 @@ double math_gamma_q(double a, double x) { return gamma_q(a, x); }
 
 // boost/math/special_functions/legendre.hpp
 double math_legendre_p(int l, double x) { return legendre_p(l, x); }
-double math_legendre_p_assoc(int l, int m, double x) {
-  return legendre_p(l, m, x);
-}
+double math_legendre_p_assoc(int l, int m, double x) { return legendre_p(l, m, x); }
 double math_legendre_p_prime(int l, double x) { return legendre_p_prime(l, x); }
+void math_legendre_p_zeros(int l, double *out) {
+    // out is assumed to be of size l.div_ceil(2)
+    auto vec = legendre_p_zeros<double>(l);
+    for (size_t i = 0; i < vec.size(); i++) {
+        out[i] = vec[i];
+    }
+}
 double math_legendre_q(unsigned l, double x) { return legendre_q(l, x); }
 
 } // extern "C"

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -20,6 +20,7 @@
 #include <boost/math/special_functions/digamma.hpp>
 #include <boost/math/special_functions/erf.hpp>
 #include <boost/math/special_functions/gamma.hpp>
+#include <boost/math/special_functions/legendre.hpp>
 
 using namespace boost::math;
 
@@ -48,5 +49,13 @@ double math_tgamma(double x) { return tgamma(x); }
 double math_lgamma(double x) { return lgamma(x); }
 double math_gamma_p(double a, double x) { return gamma_p(a, x); }
 double math_gamma_q(double a, double x) { return gamma_q(a, x); }
+
+// boost/math/special_functions/legendre.hpp
+double math_legendre_p(int l, double x) { return legendre_p(l, x); }
+double math_legendre_p_assoc(int l, int m, double x) {
+  return legendre_p(l, m, x);
+}
+double math_legendre_p_prime(int l, double x) { return legendre_p_prime(l, x); }
+double math_legendre_q(unsigned l, double x) { return legendre_q(l, x); }
 
 } // extern "C"


### PR DESCRIPTION
- `legendre_p(l: i32, x: f64) -> f64` for `legendre/2` (for `boost::math::legendre(l, x)`)
- `legendre_p_assoc(l: i32, m: i32, x: f64) -> f64` (for `boost::math::legendre(l, m, x)`)
- `legendre_p_prime(l: i32, x: f64) -> f64`
- `legendre_p_zeros(l: i32) -> Vec<f64>`
- `legendre_q(l: u32) -> f64`