### PR TITLE
Jacobi polynomials

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-//! Raw FFI declarations for wrapper.h
+//! Raw FFI declarations for wrapper.cpp
 
 use core::ffi::{c_int, c_uint};
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-//! Raw FFI declarations for cpp/wrapper.h
+//! Raw FFI declarations for wrapper.h
 
 use core::ffi::{c_int, c_uint};
 
@@ -26,6 +26,10 @@ unsafe extern "C" {
     pub fn math_lgamma(x: f64) -> f64;
     pub fn math_gamma_p(a: f64, x: f64) -> f64;
     pub fn math_gamma_q(a: f64, x: f64) -> f64;
+
+    // boost/math/special_functions/jacobi.hpp
+    pub fn math_jacobi(n: c_uint, alpha: f64, beta: f64, x: f64) -> f64;
+    pub fn math_jacobi_derivative(n: c_uint, alpha: f64, beta: f64, x: f64, k: c_uint) -> f64;
 
     // boost/math/special_functions/legendre.hpp
     pub fn math_legendre_p(l: c_int, x: f64) -> f64;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -7,4 +7,5 @@ pub use special_functions::beta::*;
 pub use special_functions::digamma::*;
 pub use special_functions::erf::*;
 pub use special_functions::gamma::*;
+pub use special_functions::jacobi::*;
 pub use special_functions::legendre::*;

--- a/src/math/special_functions/jacobi.rs
+++ b/src/math/special_functions/jacobi.rs
@@ -1,0 +1,45 @@
+//! boost/math/special_functions/jacobi.hpp
+
+use crate::ffi;
+use core::ffi::c_uint;
+
+/// Jacobi Polynomial *P<sub>n</sub><sup>(α, β)</sup>(x)*
+///
+/// Corresponds to `boost::math::jacobi(n, alpha, beta, x)`.
+///
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/jacobi.html>
+pub fn jacobi(n: u32, alpha: f64, beta: f64, x: f64) -> f64 {
+    unsafe { ffi::math_jacobi(n as c_uint, alpha, beta, x) }
+}
+
+/// *k*-th derivative of [`jacobi`] with respect to `x`
+///
+/// Corresponds to `boost::math::jacobi_derivative(n, alpha, beta, x, k)`.
+///
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/jacobi.html>
+pub fn jacobi_derivative(n: u32, alpha: f64, beta: f64, x: f64, k: u32) -> f64 {
+    unsafe { ffi::math_jacobi_derivative(n as c_uint, alpha, beta, x, k as c_uint) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jacobi() {
+        assert_eq!(jacobi(0, 2.0, 3.0, 0.5), 1.0);
+        assert_eq!(jacobi(1, 2.0, 3.0, 0.5), 1.25);
+        assert_eq!(jacobi(2, 2.0, 3.0, 0.5), 0.25);
+        assert_eq!(jacobi(3, 2.0, 3.0, 0.5), -1.015625);
+        assert_eq!(jacobi(4, 2.0, 3.0, 0.5), -1.26953125);
+    }
+
+    #[test]
+    fn test_jacobi_derivative() {
+        assert_eq!(jacobi_derivative(0, 2.0, 3.0, 0.5, 1), 0.0);
+        assert_eq!(jacobi_derivative(1, 2.0, 3.0, 0.5, 1), 3.5);
+        assert_eq!(jacobi_derivative(2, 2.0, 3.0, 0.5, 1), 7.0);
+        assert_eq!(jacobi_derivative(3, 2.0, 3.0, 0.5, 1), 4.21875);
+        assert_eq!(jacobi_derivative(4, 2.0, 3.0, 0.5, 1), -4.84375);
+    }
+}

--- a/src/math/special_functions/mod.rs
+++ b/src/math/special_functions/mod.rs
@@ -3,4 +3,5 @@ pub mod beta;
 pub mod digamma;
 pub mod erf;
 pub mod gamma;
+pub mod jacobi;
 pub mod legendre;

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -20,6 +20,7 @@
 #include <boost/math/special_functions/digamma.hpp>
 #include <boost/math/special_functions/erf.hpp>
 #include <boost/math/special_functions/gamma.hpp>
+#include <boost/math/special_functions/jacobi.hpp>
 #include <boost/math/special_functions/legendre.hpp>
 
 using namespace boost::math;
@@ -49,6 +50,14 @@ double math_tgamma(double x) { return tgamma(x); }
 double math_lgamma(double x) { return lgamma(x); }
 double math_gamma_p(double a, double x) { return gamma_p(a, x); }
 double math_gamma_q(double a, double x) { return gamma_q(a, x); }
+
+// boost/math/special_functions/jacobi.hpp
+double math_jacobi(unsigned n, double alpha, double beta, double x) {
+    return jacobi(n, alpha, beta, x);
+}
+double math_jacobi_derivative(unsigned n, double alpha, double beta, double x, unsigned k) {
+    return jacobi_derivative(n, alpha, beta, x, k);
+}
 
 // boost/math/special_functions/legendre.hpp
 double math_legendre_p(int l, double x) { return legendre_p(l, x); }


### PR DESCRIPTION
- `jacobi(n: u32, alpha: f64, beta: f64, x: f64)`
- `jacobi_derivative(n: u32, alpha: f64, beta: f64, x: f64, k: u32)`

Note that `jacobi_prime` and `jacobi_double_prime` were intentionally omitted. These directly call `jacobi_derivate` with `k=1` and `k=2` respectively, and are therefore not worth the additional API surface IMO.