### PR TITLE
incomplete Beta functions, complements and inverses

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -13,6 +13,17 @@ unsafe extern "C" {
 
     // boost/math/special_functions/beta.hpp
     pub fn math_beta(a: f64, b: f64) -> f64;
+    pub fn math_beta_(a: f64, b: f64, x: f64) -> f64;
+    pub fn math_betac(a: f64, b: f64, x: f64) -> f64;
+    pub fn math_ibeta(a: f64, b: f64, x: f64) -> f64;
+    pub fn math_ibeta_derivative(a: f64, b: f64, x: f64) -> f64;
+    pub fn math_ibeta_inv(a: f64, b: f64, p: f64) -> f64;
+    pub fn math_ibeta_inva(b: f64, x: f64, p: f64) -> f64;
+    pub fn math_ibeta_invb(a: f64, x: f64, p: f64) -> f64;
+    pub fn math_ibetac(a: f64, b: f64, x: f64) -> f64;
+    pub fn math_ibetac_inv(a: f64, b: f64, q: f64) -> f64;
+    pub fn math_ibetac_inva(b: f64, x: f64, q: f64) -> f64;
+    pub fn math_ibetac_invb(a: f64, x: f64, q: f64) -> f64;
 
     // boost/math/special_functions/digamma.hpp
     pub fn math_digamma(x: f64) -> f64;

--- a/src/math/special_functions/beta.rs
+++ b/src/math/special_functions/beta.rs
@@ -1,49 +1,206 @@
 //! boost/math/special_functions/beta.hpp
-//!
-//! # TODO:
-//! - `ibeta`
-//! - `ibetac`
-//! - `ibeta_derivative`
-//! - `beta` (3-parameter version)
-//! - `betac`
 
 use crate::ffi;
 
-/// Beta function *B(a,b) = Γ(a) Γ(b) / Γ(a + b)*
+/// Beta function *B(a,b)*
 ///
+/// *B(a,b) = B<sub>1</sub>(a,b) = Γ(a) Γ(b) / Γ(a + b)*
+///
+/// See also:
+/// - [`beta_`]: Incomplete Beta function *B<sub>x</sub>(a,b)*.
+/// - [`ibeta`]: Regularized incomplete Beta function *I<sub>x</sub>(a,b)*.
+///
+/// Corresponds to `boost::math::beta(a, b)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/beta_function.html>
-///
-/// Defined in `boost/math/special_functions/beta.hpp`
 pub fn beta(a: f64, b: f64) -> f64 {
     unsafe { ffi::math_beta(a, b) }
 }
 
+/// Incomplete Beta function *B<sub>x</sub>(a,b)*
+///
+/// Requires *a > 0* and *b > 0*.
+///
+/// See also:
+/// - [`beta`]: Beta function *B(a,b) = B<sub>1</sub>(a,b)*.
+/// - [`betac`]: Complement of the Beta function *B<sub>x</sub>(a,b)*.
+/// - [`ibeta`]: Regularized incomplete Beta function *I<sub>x</sub>(a,b)*.
+///
+/// Corresponds to `boost::math::beta(a, b, x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_function.html>
+pub fn beta_(a: f64, b: f64, x: f64) -> f64 {
+    unsafe { ffi::math_beta_(a, b, x) }
+}
+
+/// Complement of [`beta_`]
+///
+/// That is, *1 - B<sub>x</sub>(a,b) = B<sub>1-x</sub>(b,a)*.
+///
+/// Corresponds to `boost::math::betac(a, b, x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_function.html>
+pub fn betac(a: f64, b: f64, x: f64) -> f64 {
+    unsafe { ffi::math_betac(a, b, x) }
+}
+
+/// Regularized incomplete Beta function *I<sub>x</sub>(a,b)*
+///
+/// Requires *a ≥ 0* and *b ≥ 0* s.t. *a + b > 0*.
+///
+/// *I<sub>x</sub>(a,b) = B<sub>x</sub>(a,b) / B(a,b)*.
+///
+/// See also:
+/// - [`beta`]: Beta function *B(a,b)*.
+/// - [`beta_`]: Incomplete Beta function *B<sub>x</sub>(a,b)*.
+/// - [`ibetac`]: Complement of the regularized incomplete Beta function
+///
+/// Corresponds to `boost::math::ibeta(a, b, x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_function.html>
+pub fn ibeta(a: f64, b: f64, x: f64) -> f64 {
+    unsafe { ffi::math_ibeta(a, b, x) }
+}
+
+/// Derivative of [`ibeta`] w.r.t. `x`, *I'<sub>x</sub>(a,b)*
+///
+/// *I'<sub>x</sub>(a,b) = x<sup>a-1</sup> (1-x)<sup>b-1</sup> / B(a,b)*
+///
+/// Note that this is the probability density function of the Beta distribution.
+///
+/// Corresponds to `boost::math::ibeta_derivative(a, b, x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/beta_derivative.html>
+pub fn ibeta_derivative(a: f64, b: f64, x: f64) -> f64 {
+    unsafe { ffi::math_ibeta_derivative(a, b, x) }
+}
+
+/// Inverse of [`ibeta`] w.r.t. `x`
+///
+/// Corresponds to `boost::math::ibeta_inv(a, b, p)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html>
+pub fn ibeta_inv(a: f64, b: f64, p: f64) -> f64 {
+    unsafe { ffi::math_ibeta_inv(a, b, p) }
+}
+
+/// Inverse of [`ibeta`] w.r.t. `a`
+///
+/// Corresponds to `boost::math::ibeta_inva(b, x, p)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html>
+pub fn ibeta_inva(b: f64, x: f64, p: f64) -> f64 {
+    unsafe { ffi::math_ibeta_inva(b, x, p) }
+}
+
+/// Inverse of [`ibeta`] w.r.t. `b`
+///
+/// Corresponds to `boost::math::ibeta_invb(a, x, p)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html>
+pub fn ibeta_invb(a: f64, x: f64, p: f64) -> f64 {
+    unsafe { ffi::math_ibeta_invb(a, x, p) }
+}
+
+/// Complement of [`ibeta`]
+///
+/// That is, *1 - I<sub>x</sub>(a,b) = I<sub>1-x</sub>(b,a)*.
+///
+/// Corresponds to `boost::math::ibetac(a, b, x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_function.html>
+pub fn ibetac(a: f64, b: f64, x: f64) -> f64 {
+    unsafe { ffi::math_ibetac(a, b, x) }
+}
+
+/// Inverse of [`ibetac`] w.r.t. `x`
+///
+/// Corresponds to `boost::math::ibetac_inv(a, b, p)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html>
+pub fn ibetac_inv(a: f64, b: f64, p: f64) -> f64 {
+    unsafe { ffi::math_ibetac_inv(a, b, p) }
+}
+
+/// Inverse of [`ibetac`] w.r.t. `a`
+///
+/// Corresponds to `boost::math::ibetac_inva(b, x, p)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html>
+pub fn ibetac_inva(b: f64, x: f64, p: f64) -> f64 {
+    unsafe { ffi::math_ibetac_inva(b, x, p) }
+}
+
+/// Inverse of [`ibetac`] w.r.t. `b`
+///
+/// Corresponds to `boost::math::ibetac_invb(a, x, p)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_beta/ibeta_inv_function.html>
+pub fn ibetac_invb(a: f64, x: f64, p: f64) -> f64 {
+    unsafe { ffi::math_ibetac_invb(a, x, p) }
+}
+
 #[cfg(test)]
-mod tests {
+mod smoketests {
     use super::*;
 
     #[test]
-    fn test_beta_symmetry() {
-        let (a, b) = (2.0, 3.0);
-        assert_eq!(beta(a, b), beta(b, a));
+    fn test_beta() {
+        let result = beta(0.5, 0.5);
+        assert_relative_eq!(result, core::f64::consts::PI, epsilon = f64::EPSILON);
     }
 
     #[test]
-    fn test_beta_literal() {
-        assert_eq!(beta(1.0, 1.0), 1.0);
-        assert_eq!(beta(5.0, 1.0), 0.2);
+    fn test_beta_() {
+        let result = beta_(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
     }
 
     #[test]
-    fn test_beta_nan() {
-        assert!(beta(f64::NAN, 1.0).is_nan());
-        assert!(beta(1.0, f64::NAN).is_nan());
+    fn test_betac() {
+        let result = betac(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
     }
 
     #[test]
-    fn test_beta_invalid() {
-        assert!(beta(-1.0, -1.0).is_nan());
-        assert!(beta(-1.0, 1.0).is_nan());
-        assert!(beta(1.0, -1.0).is_nan());
+    fn test_ibeta() {
+        let result = ibeta(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibeta_derivative() {
+        let result = ibeta_derivative(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibeta_inv() {
+        let result = ibeta_inv(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibeta_inva() {
+        let result = ibeta_inva(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibeta_invb() {
+        let result = ibeta_invb(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibetac() {
+        let result = ibetac(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibetac_inv() {
+        let result = ibetac_inv(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibetac_inva() {
+        let result = ibetac_inva(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
+    }
+
+    #[test]
+    fn test_ibetac_invb() {
+        let result = ibetac_invb(0.5, 0.5, 0.5);
+        assert!(result.is_finite());
     }
 }

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -38,6 +38,17 @@ double math_sph_neumann(unsigned n, double x) { return sph_neumann(n, x); }
 
 // boost/math/special_functions/beta.hpp
 double math_beta(double a, double b) { return beta(a, b); }
+double math_beta_(double a, double b, double x) { return beta(a, b, x); }
+double math_betac(double a, double b, double x) { return beta(a, b, x); }
+double math_ibeta(double a, double b, double x) { return ibeta(a, b, x); }
+double math_ibeta_derivative(double a, double b, double x) { return ibeta_derivative(a, b, x); }
+double math_ibeta_inv(double a, double b, double p) { return ibeta_inv(a, b, p); }
+double math_ibeta_inva(double b, double x, double p) { return ibeta_inva(b, x, p); }
+double math_ibeta_invb(double a, double x, double p) { return ibeta_invb(a, x, p); }
+double math_ibetac(double a, double b, double x) { return ibetac(a, b, x); }
+double math_ibetac_inv(double a, double b, double q) { return ibetac_inv(a, b, q); }
+double math_ibetac_inva(double b, double x, double q) { return ibetac_inva(b, x, q); }
+double math_ibetac_invb(double a, double x, double q) { return ibetac_invb(a, x, q); }
 
 // boost/math/special_functions/digamma.hpp
 double math_digamma(double x) { return digamma(x); }


### PR DESCRIPTION
This adds the remaining functions from `boost/math/special_functions/beta.hpp`:

- `beta_(a, b, x)`
- `betac(a, b, x)`
- `ibeta(a, b, x)`
- `ibeta_derivative(a, b, x)`
- `ibeta_inv(a, b, p)`
- `ibeta_inva(b, x, p)`
- `ibeta_invb(a, x, p)`
- `ibetac(a, b, x)`
- `ibetac_inv(a, b, q)`
- `ibetac_inva(b, x, q)`
- `ibetac_invb(a, x, q)`