### PR TITLE
`trigamma` and `polygamma`

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -84,8 +84,14 @@ unsafe extern "C" {
     pub fn math_legendre_p_zeros(l: c_int, out: *mut f64);
     pub fn math_legendre_q(l: c_uint, x: f64) -> f64;
 
+    // boost/math/special_functions/polygamma.hpp
+    pub fn math_polygamma(n: c_int, x: f64) -> f64;
+
     // boost/math/special_functions/prime.hpp
     pub fn math_prime(n: c_uint) -> u32;
+
+    // boost/math/special_functions/trigamma.hpp
+    pub fn math_trigamma(x: f64) -> f64;
 
     // boost/math/special_functions/zeta.hpp
     pub fn math_zeta(s: f64) -> f64;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -21,10 +21,10 @@
 //!   - [`gamma1pm1`]
 //! - [x] Log Gamma
 //!   - [`lgamma`]
-//! - [x] Digamma
+//! - [x] Polygamma
 //!   - [`digamma`]
-//! - [ ] Trigamma
-//! - [ ] Polygamma
+//!   - [`trigamma`]
+//!   - [`polygamma`]
 //! - [x] Ratios of Gamma Functions
 //!   - [`gamma_ratio`]
 //!   - [`gamma_delta_ratio`]
@@ -85,7 +85,7 @@
 //!   - [`legendre_p_zeros`]
 //!   - [`legendre_p_assoc`]
 //!   - [`legendre_q`]
-//! - [ ] Legendre-Stieltjes Polynomials
+//! - [ ] ~Legendre-Stieltjes Polynomials~
 //! - [ ] Laguerre (and Associated) Polynomials
 //! - [ ] Hermite Polynomials
 //! - [ ] Chebyshev Polynomials
@@ -173,7 +173,7 @@
 //! - [ ] Exponential Integral *En*
 //! - [ ] Exponential Integral *Ei*
 //!
-//! <h4>Hypergeometric Functions</h4>
+//! ### Hypergeometric Functions
 //!
 //! - [x] Hypergeometric *<sub>1</sub>F<sub>0</sub>*
 //!   - [`hypergeometric_1f0`]
@@ -228,5 +228,7 @@ pub use special_functions::gamma::*;
 pub use special_functions::hypergeometric::*;
 pub use special_functions::jacobi::*;
 pub use special_functions::legendre::*;
+pub use special_functions::polygamma::*;
 pub use special_functions::prime::*;
+pub use special_functions::trigamma::*;
 pub use special_functions::zeta::*;

--- a/src/math/special_functions/digamma.rs
+++ b/src/math/special_functions/digamma.rs
@@ -2,8 +2,9 @@
 
 use crate::ffi;
 
-/// Digamma function *ψ(x) = Γ'(x) / Γ(x)*
+/// Digamma function *𝟊(x) = Γ'(x)/Γ(x)*
 ///
+/// Corresponds to `boost::math::digamma(x)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_gamma/digamma.html>
 pub fn digamma(x: f64) -> f64 {
     unsafe { ffi::math_digamma(x) }
@@ -11,24 +12,24 @@ pub fn digamma(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    const ATOL: f64 = 5e-16;
+    use super::*;
+
+    const RTOL: f64 = 1e-15;
 
     #[test]
     fn test_digamma_roots() {
-        assert_abs_diff_eq!(
-            crate::math::digamma(1.461_632_144_968_362_3),
-            0.0,
-            epsilon = ATOL,
-        );
-        assert_abs_diff_eq!(
-            crate::math::digamma(-0.504_083_008_264_455_4),
-            0.0,
-            epsilon = ATOL,
-        );
-        assert_abs_diff_eq!(
-            crate::math::digamma(-1.573_498_473_162_390_5),
-            0.0,
-            epsilon = ATOL,
-        );
+        assert_relative_eq!(digamma(1.461_632_144_968_362_3), 0.0, epsilon = RTOL);
+        assert_relative_eq!(digamma(-0.504_083_008_264_455_4), 0.0, epsilon = RTOL);
+        assert_relative_eq!(digamma(-1.573_498_473_162_390_5), 0.0, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_digamma_singularities() {
+        assert!(digamma(f64::NAN).is_nan());
+        assert_eq!(digamma(f64::INFINITY), f64::INFINITY);
+        assert!(digamma(0.0).is_nan());
+        assert!(digamma(-1.0).is_nan());
+        assert!(digamma(-2.0).is_nan());
+        assert!(digamma(-f64::INFINITY).is_nan());
     }
 }

--- a/src/math/special_functions/gamma.rs
+++ b/src/math/special_functions/gamma.rs
@@ -72,7 +72,7 @@ pub fn gamma_delta_ratio(x: f64, delta: f64) -> f64 {
     unsafe { ffi::math_tgamma_delta_ratio(x, delta) }
 }
 
-/// Natural logarithm of the absolute value of the gamma function
+/// Natural logarithm of the absolute value of the gamma function *ln |Γ(x)|*
 ///
 /// The integer part of the tuple indicates the sign of the gamma function.
 ///

--- a/src/math/special_functions/mod.rs
+++ b/src/math/special_functions/mod.rs
@@ -8,5 +8,7 @@ pub mod gamma;
 pub mod hypergeometric;
 pub mod jacobi;
 pub mod legendre;
+pub mod polygamma;
 pub mod prime;
+pub mod trigamma;
 pub mod zeta;

--- a/src/math/special_functions/polygamma.rs
+++ b/src/math/special_functions/polygamma.rs
@@ -95,9 +95,9 @@ mod tests {
         ); // +0
 
         for x in [0.0, -1.0, -2.0] {
-            assert!(polygamma(0, x).is_nan()); // intedeterminate
+            assert!(polygamma(0, x).is_nan()); // indeterminate
             assert!(is_pinf(polygamma(1, x))); // +∞
-            assert!(polygamma(2, 0.0).is_nan()); // intedeterminate
+            assert!(polygamma(2, 0.0).is_nan()); // indeterminate
             assert!(is_pinf(polygamma(3, x))); // +∞
         }
     }

--- a/src/math/special_functions/polygamma.rs
+++ b/src/math/special_functions/polygamma.rs
@@ -1,0 +1,104 @@
+//! boost/math/special_functions/polygamma.hpp
+
+use crate::ffi;
+use core::ffi::c_int;
+
+/// Polygamma function *𝟊<sup>(n)</sup>(x)*
+///
+/// For *n > 0*, Polygamma is defined as the *n*<sup>th</sup> derivative of the
+/// [`digamma`](crate::math::digamma) function *𝟊(x)*.
+///
+/// Special cases:
+/// - For `n = 0`, this is equivalent to the [`digamma`](crate::math::digamma) function *𝟊(x)*
+/// - For `n = 1`, this is equivalent to the [`trigamma`](crate::math::trigamma) function
+///   *𝟊<sup>(1)</sup>(x)*
+/// - For `n = -1` and `x > 0`, this is equivalent to the [`lgamma`](crate::math::lgamma) function
+///   *ln |Γ(x)|*
+///
+/// Corresponds to `boost::math::polygamma(x)` in C++, with some minor corrections related to
+/// infinities and negative integers.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_gamma/polygamma.html>.
+pub fn polygamma(n: i32, x: f64) -> f64 {
+    if n < -1 {
+        todo!("polygamma not implemented for n < -1");
+    }
+    unsafe { ffi::math_polygamma(n as c_int, x) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RTOL: f64 = 1e-15;
+    const ZETA_2: f64 = 1.644_934_066_848_226_4; // ζ(2) = π²/6
+
+    fn is_pzero(x: f64) -> bool {
+        x == 0.0 && x.is_sign_positive()
+    }
+
+    fn is_nzero(x: f64) -> bool {
+        x == 0.0 && x.is_sign_negative()
+    }
+
+    fn is_pinf(x: f64) -> bool {
+        x.is_infinite() && x.is_sign_positive()
+    }
+
+    #[test]
+    fn test_polygamma_0() {
+        // Same as digamma tests
+        assert_relative_eq!(polygamma(0, 1.461_632_144_968_362_3), 0.0, epsilon = RTOL);
+        assert_relative_eq!(polygamma(0, -0.504_083_008_264_455_4), 0.0, epsilon = RTOL);
+        assert_relative_eq!(polygamma(0, -1.573_498_473_162_390_5), 0.0, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_polygamma_1() {
+        // Same as trigamma tests
+        assert_abs_diff_eq!(polygamma(1, 1.0), ZETA_2, epsilon = RTOL);
+        assert_abs_diff_eq!(polygamma(1, 2.0), ZETA_2 - 1.0, epsilon = RTOL);
+        assert_abs_diff_eq!(polygamma(1, 3.0), ZETA_2 - 1.25, epsilon = RTOL);
+
+        assert_abs_diff_eq!(polygamma(1, -1.5), 3.0 * ZETA_2 + 4.0 / 0.9, epsilon = RTOL);
+        assert_abs_diff_eq!(polygamma(1, -0.5), 3.0 * ZETA_2 + 4.0, epsilon = RTOL);
+        assert_abs_diff_eq!(polygamma(1, 0.5), 3.0 * ZETA_2, epsilon = RTOL);
+        assert_abs_diff_eq!(polygamma(1, 1.5), 3.0 * ZETA_2 - 4.0, epsilon = RTOL);
+        assert_abs_diff_eq!(polygamma(1, 2.5), 3.0 * ZETA_2 - 4.0 / 0.9, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_polygamma_singularities() {
+        for n in 0..=3 {
+            assert!(polygamma(n, f64::NAN).is_nan());
+            assert!(polygamma(n, -f64::INFINITY).is_nan());
+        }
+
+        assert!(
+            is_pinf(polygamma(0, f64::INFINITY)),
+            "{} != +∞",
+            polygamma(0, f64::INFINITY)
+        ); // +∞
+        assert!(
+            is_pzero(polygamma(1, f64::INFINITY)),
+            "{} != +0.0",
+            polygamma(1, f64::INFINITY)
+        ); // +0
+        assert!(
+            is_nzero(polygamma(2, f64::INFINITY)),
+            "{} != -0.0",
+            polygamma(2, f64::INFINITY)
+        ); // -0
+        assert!(
+            is_pzero(polygamma(3, f64::INFINITY)),
+            "{} != +0.0",
+            polygamma(3, f64::INFINITY)
+        ); // +0
+
+        for x in [0.0, -1.0, -2.0] {
+            assert!(polygamma(0, x).is_nan()); // intedeterminate
+            assert!(is_pinf(polygamma(1, x))); // +∞
+            assert!(polygamma(2, 0.0).is_nan()); // intedeterminate
+            assert!(is_pinf(polygamma(3, x))); // +∞
+        }
+    }
+}

--- a/src/math/special_functions/trigamma.rs
+++ b/src/math/special_functions/trigamma.rs
@@ -1,0 +1,46 @@
+//! boost/math/special_functions/trigamma.hpp
+
+use crate::ffi;
+
+/// Trigamma function *𝟊<sup>(1)</sup>(x)*
+///
+/// Trigamma is defined as the derivative of the [`digamma`](crate::math::digamma) function *𝟊(x)*,
+/// and a special case of the [`polygamma`](crate::math::polygamma) function *𝟊<sup>(n)</sup>(x)*
+/// for *n = 1*.
+///
+/// Corresponds to `boost::math::trigamma(x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_gamma/trigamma.html>
+pub fn trigamma(x: f64) -> f64 {
+    unsafe { ffi::math_trigamma(x) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RTOL: f64 = 1e-15;
+    const ZETA_2: f64 = 1.644_934_066_848_226_4; // ζ(2) = π²/6
+
+    #[test]
+    fn test_trigamma() {
+        assert_abs_diff_eq!(trigamma(1.0), ZETA_2, epsilon = RTOL);
+        assert_abs_diff_eq!(trigamma(2.0), ZETA_2 - 1.0, epsilon = RTOL);
+        assert_abs_diff_eq!(trigamma(3.0), ZETA_2 - 1.25, epsilon = RTOL);
+
+        assert_abs_diff_eq!(trigamma(-1.5), 3.0 * ZETA_2 + 4.0 / 0.9, epsilon = RTOL);
+        assert_abs_diff_eq!(trigamma(-0.5), 3.0 * ZETA_2 + 4.0, epsilon = RTOL);
+        assert_abs_diff_eq!(trigamma(0.5), 3.0 * ZETA_2, epsilon = RTOL);
+        assert_abs_diff_eq!(trigamma(1.5), 3.0 * ZETA_2 - 4.0, epsilon = RTOL);
+        assert_abs_diff_eq!(trigamma(2.5), 3.0 * ZETA_2 - 4.0 / 0.9, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_trigamma_singularities() {
+        assert!(trigamma(f64::NAN).is_nan());
+        assert_eq!(trigamma(f64::INFINITY), 0.0);
+        assert_eq!(trigamma(0.0), f64::INFINITY);
+        assert_eq!(trigamma(-1.0), f64::INFINITY);
+        assert_eq!(trigamma(-2.0), f64::INFINITY);
+        assert!(trigamma(-f64::INFINITY).is_nan());
+    }
+}

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -49,9 +49,9 @@ inline double polygamma(const int n, double x) {
         } else {
             // polygamma(n, ∞) = 0 in the limit for n > 0
             if (n % 2) {
-                return 0.0; // even
+                return 0.0; // odd
             } else {
-                return -0.0; // odd
+                return -0.0; // even
             }
         }
     } else if (x <= 0 && floor(x) == x) {


### PR DESCRIPTION
the boost implementation apparently doesn't handle infinities and NaN's properly, so it required some special casing to be added to the `boost::math::polygamma` C++ wrapper function 