### PR TITLE
Orthogonal polynomial recurrence relations

### DIFF
--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -90,6 +90,8 @@
 //!   - [`legendre_p_zeros`]
 //!   - [`legendre_p_assoc`]
 //!   - [`legendre_q`]
+//!   - [`legendre_next`]
+//!   - [`legendre_assoc_next`]
 //! - [x] Laguerre (and Associated) Polynomials
 //!   - [`laguerre`]
 //!   - [`laguerre_assoc`]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -99,6 +99,7 @@
 //!   - [`laguerre_assoc_next`]
 //! - [x] Hermite Polynomials
 //!   - [`hermite`]
+//!   - [`hermite_next`]
 //! - [x] Gegenbauer Polynomials
 //!   - [`gegenbauer`]
 //!   - [`gegenbauer_derivative`]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -88,13 +88,15 @@
 //!   - [`legendre_p`]
 //!   - [`legendre_p_prime`]
 //!   - [`legendre_p_zeros`]
-//!   - [`legendre_p_assoc`]
 //!   - [`legendre_q`]
 //!   - [`legendre_next`]
+//!   - [`legendre_p_assoc`]
 //!   - [`legendre_assoc_next`]
 //! - [x] Laguerre (and Associated) Polynomials
 //!   - [`laguerre`]
+//!   - [`laguerre_next`]
 //!   - [`laguerre_assoc`]
+//!   - [`laguerre_assoc_next`]
 //! - [x] Hermite Polynomials
 //!   - [`hermite`]
 //! - [x] Gegenbauer Polynomials

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -83,6 +83,7 @@
 //!   - [`chebyshev_t`]
 //!   - [`chebyshev_t_prime`]
 //!   - [`chebyshev_u`]
+//!   - [`chebyshev_next`]
 //! - [x] Legendre (and associated) polynomials
 //!   - [`legendre_p`]
 //!   - [`legendre_p_prime`]

--- a/src/math/special_functions/chebyshev.rs
+++ b/src/math/special_functions/chebyshev.rs
@@ -2,7 +2,46 @@
 
 use crate::ffi;
 
-/// Chebyshev polynomial of the first kind T<sub>n</sub>(x).
+/// Recurrence relation for Chebyshev polynomials
+///
+/// *T<sub>n+1</sub>(x) = 2 x T<sub>n</sub>(x) - T<sub>n-1</sub>(x)*
+///
+/// Note that this applies to both the first and second kinds.
+///
+/// # Examples
+///
+/// [`chebyshev_t`] recurrence:
+///
+/// ```
+/// # use boost::math::{chebyshev_t, chebyshev_next};
+/// let x = 0.42;
+/// let t0 = chebyshev_t(0, x); // 1
+/// let t1 = chebyshev_t(1, x); // x
+/// let t2 = chebyshev_t(2, x); // 2x² - 1
+/// let t3 = chebyshev_t(3, x); // 4x³ - 3x
+/// assert_eq!(chebyshev_next(&x, &t1, &t0), t2);
+/// assert_eq!(chebyshev_next(&x, &t2, &t1), t3);
+/// ```
+///
+/// [`chebyshev_u`] recurrence:
+///
+/// ```
+/// # use boost::math::{chebyshev_u, chebyshev_next};
+/// let x = 0.42;
+/// let u0 = chebyshev_u(0, x); // 1
+/// let u1 = chebyshev_u(1, x); // 2x
+/// let u2 = chebyshev_u(2, x); // 4x² - 1
+/// let u3 = chebyshev_u(3, x); // 8x³ - 4x
+/// assert_eq!(chebyshev_next(&x, &u1, &u0), u2);
+/// assert_eq!(chebyshev_next(&x, &u2, &u1), u3);
+/// ```
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn chebyshev_next(x: &f64, Tn: &f64, Tn_1: &f64) -> f64 {
+    2.0 * x * Tn - Tn_1
+}
+
+/// Chebyshev polynomial of the 1st kind T<sub>n</sub>(x).
 ///
 /// Defined as <i>T<sub>n</sub>(</i>cos<i>(θ)) = </i>cos<i>(n θ)</i>.
 ///
@@ -23,7 +62,7 @@ pub fn chebyshev_t_prime(n: u32, x: f64) -> f64 {
     unsafe { ffi::math_chebyshev_t_prime(n, x) }
 }
 
-/// Chebyshev polynomial of the second kind U<sub>n</sub>(x).
+/// Chebyshev polynomial of the 2nd kind U<sub>n</sub>(x).
 ///
 /// Defined as <i>U<sub>n</sub>(</i>cos<i>(θ)) = </i>sin<i>((n+1) θ) / </i>sin<i>(θ)</i>.
 ///

--- a/src/math/special_functions/hermite.rs
+++ b/src/math/special_functions/hermite.rs
@@ -11,6 +11,28 @@ pub fn hermite(n: u32, x: f64) -> f64 {
     unsafe { ffi::math_hermite(n as c_uint, x) }
 }
 
+/// Recurrence relation for [`hermite`]
+///
+/// *H<sub>n+1</sub>(x) = 2xH<sub>n</sub>(x) - 2nH<sub>n-1</sub>(x)*
+///
+/// # Examples
+///
+/// ```
+/// # use boost::math::{hermite, hermite_next};
+/// let x = 0.42;
+/// let h0 = hermite(0, x); // 1
+/// let h1 = hermite(1, x); // 2x
+/// let h2 = hermite(2, x); // 4x² - 2
+/// let h3 = hermite(3, x); // 8x³ - 12x
+/// assert_eq!(hermite_next(1, &x, &h1, &h0), h2);
+/// assert_eq!(hermite_next(2, &x, &h2, &h1), h3);
+/// ```
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn hermite_next(n: u32, x: &f64, Hn: &f64, Hn_1: &f64) -> f64 {
+    2.0 * (x * Hn - (n as f64) * Hn_1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/math/special_functions/laguerre.rs
+++ b/src/math/special_functions/laguerre.rs
@@ -23,6 +23,62 @@ pub fn laguerre_assoc(n: u32, m: u32, x: f64) -> f64 {
     unsafe { ffi::math_laguerre_assoc(n as c_uint, m as c_uint, x) }
 }
 
+/// Recurrence relation for [`laguerre`]
+///
+/// *(n+1)L<sub>n+1</sub>(x) = (2n+1-x)L<sub>n</sub>(x) - nL<sub>n-1</sub>(x)*
+///
+/// # Examples
+///
+/// ```
+/// # use boost::math::{laguerre, laguerre_next};
+/// let x = 0.42;
+/// let l0 = laguerre(0, x); // 1
+/// let l1 = laguerre(1, x); // -x + 1
+/// let l2 = laguerre(2, x); // (x² - -4x + 2) / 2
+/// let l3 = laguerre(3, x); // (-x³ + 9x² - 18x + 6) / 6
+/// assert_eq!(laguerre_next(1, &x, &l1, &l0), l2);
+/// assert_eq!(laguerre_next(2, &x, &l2, &l1), l3);
+/// ```
+///
+/// # See also
+///
+/// - [`laguerre`]
+/// - [`laguerre_assoc_next`]
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn laguerre_next(n: u32, x: &f64, Ln: &f64, Ln_1: &f64) -> f64 {
+    laguerre_assoc_next(n, 0, x, Ln, Ln_1)
+}
+
+/// Recurrence relation for [`laguerre_assoc`]
+///
+/// *(n+1)L<sub>n+1</sub><sup>m</sup>(x)
+/// = (2n+m+1-x)L<sub>n</sub><sup>m</sup>(x) - (n+m)L<sub>n-1</sub><sup>m</sup>(x)*
+///
+/// # Examples
+///
+/// ```
+/// # use boost::math::{laguerre_assoc, laguerre_assoc_next};
+/// let m = 3;
+/// let x = 0.42;
+/// let l0 = laguerre_assoc(0, m, x);
+/// let l1 = laguerre_assoc(1, m, x);
+/// let l2 = laguerre_assoc(2, m, x);
+/// let l3 = laguerre_assoc(3, m, x);
+/// assert_eq!(laguerre_assoc_next(1, m, &x, &l1, &l0), l2);
+/// assert_eq!(laguerre_assoc_next(2, m, &x, &l2, &l1), l3);
+/// ```
+///
+/// # See also
+///
+/// - [`laguerre_assoc`]
+/// - [`laguerre_next`]
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn laguerre_assoc_next(n: u32, m: u32, x: &f64, Ln: &f64, Ln_1: &f64) -> f64 {
+    (((2 * n + m + 1) as f64 - x) * Ln - (n + m) as f64 * Ln_1) / (n + 1) as f64
+}
+
 #[cfg(test)]
 mod tests {
     use crate::math::{laguerre, laguerre_assoc};

--- a/src/math/special_functions/legendre.rs
+++ b/src/math/special_functions/legendre.rs
@@ -8,56 +8,123 @@ use crate::ffi;
 use alloc::{vec, vec::Vec};
 use core::ffi::{c_int, c_uint};
 
-/// Legendre Polynomial of the 1st kind *P<sub>l</sub>(x)* on *[-1, 1]*
+/// Legendre Polynomial of the 1st kind *P<sub>n</sub>(x)* on *[-1, 1]*
 ///
-/// Corresponds to `boost::math::legendre_p(l, x)`.
-///
+/// Corresponds to `boost::math::legendre_p(n, x)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
-pub fn legendre_p(l: i32, x: f64) -> f64 {
-    unsafe { ffi::math_legendre_p(l as c_int, x) }
+pub fn legendre_p(n: i32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_p(n as c_int, x) }
 }
 
-/// Associated Legendre Polynomial of the 1st kind *P<sub>l</sub><sup>m</sup>(x)* on *[-1, 1]*
+/// Derivative of [`legendre_p`] with respect to `x`; *P'<sub>n</sub>(x)*
 ///
-/// Corresponds to `boost::math::legendre_p(l, m, x)`.
-///
+/// Corresponds to `boost::math::legendre_p_prime(n, x)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
-pub fn legendre_p_assoc(l: i32, m: i32, x: f64) -> f64 {
-    unsafe { ffi::math_legendre_p_assoc(l as c_int, m as c_int, x) }
+pub fn legendre_p_prime(n: i32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_p_prime(n as c_int, x) }
 }
 
-/// Derivative of [`legendre_p`] with respect to `x`; *P'<sub>l</sub>(x)*
+/// Associated Legendre Polynomial of the 1st kind *P<sub>n</sub><sup>m</sup>(x)* on *[-1, 1]*
 ///
-/// Corresponds to `boost::math::legendre_p_prime(l, x)`.
-///
+/// Corresponds to `boost::math::legendre_p(n, m, x)` in C++
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
-pub fn legendre_p_prime(l: i32, x: f64) -> f64 {
-    unsafe { ffi::math_legendre_p_prime(l as c_int, x) }
+pub fn legendre_p_assoc(n: i32, m: i32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_p_assoc(n as c_int, m as c_int, x) }
 }
 
 /// Zeros (roots) of [`legendre_p`] on *[0, 1]*.
 ///
-/// Note that only the non-negative zeros are returned, of which there are `l.div_ceil(2)`.
+/// Note that only the non-negative zeros are returned, of which there are `n.div_ceil(2)`.
 ///
-/// Corresponds to `boost::math::legendre_p_zeros<double>(l)`.
-///
+/// Corresponds to `boost::math::legendre_p_zeros<double>(n)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
-pub fn legendre_p_zeros(l: i32) -> Vec<f64> {
+pub fn legendre_p_zeros(n: i32) -> Vec<f64> {
     // total number of zeros
-    let k = (if l < 0 { -l - 1 } else { l }) as usize;
+    let k = (if n < 0 { -n - 1 } else { n }) as usize;
     // number of positive zeros
     let mut out = vec![f64::NAN; k.div_ceil(2)];
-    unsafe { ffi::math_legendre_p_zeros(l as c_int, out.as_mut_ptr()) };
+    unsafe { ffi::math_legendre_p_zeros(n as c_int, out.as_mut_ptr()) };
     out
 }
 
-/// Legendre Polynomial of the 2nd kind *Q<sub>l</sub>(x)* on *[-1, 1]*
+/// Legendre Polynomial of the 2nd kind *Q<sub>n</sub>(x)* on *[-1, 1]*
 ///
-/// Corresponds to `boost::math::legendre_q(l, x)`.
-///
+/// Corresponds to `boost::math::legendre_q(n, x)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/legendre.html>
-pub fn legendre_q(l: u32, x: f64) -> f64 {
-    unsafe { ffi::math_legendre_q(l as c_uint, x) }
+pub fn legendre_q(n: u32, x: f64) -> f64 {
+    unsafe { ffi::math_legendre_q(n as c_uint, x) }
+}
+
+/// Recurrence relation for [`legendre_p`] and [`legendre_q`]
+///
+/// *(n+1)P<sub>n+1</sub>(x) = (2n+1)xP<sub>n</sub>(x) - nP<sub>n-1</sub>(x)*
+///
+/// # Examples
+///
+/// [`legendre_p`] recurrence:
+///
+/// ```
+/// # use boost::math::{legendre_p, legendre_next};
+/// let x = 0.42;
+/// let p0 = legendre_p(0, x); // 1
+/// let p1 = legendre_p(1, x); // x
+/// let p2 = legendre_p(2, x); // (3x² - 1) / 2
+/// let p3 = legendre_p(3, x); // (5x³ - 3x) / 2
+/// assert_eq!(legendre_next(1, &x, &p1, &p0), p2);
+/// assert_eq!(legendre_next(2, &x, &p2, &p1), p3);
+/// ```
+///
+/// [`legendre_q`] recurrence:
+///
+/// ```
+/// # use boost::math::{legendre_q, legendre_next};
+/// let x = 0.42;
+/// let q0 = legendre_q(0, x);
+/// let q1 = legendre_q(1, x);
+/// let q2 = legendre_q(2, x);
+/// let q3 = legendre_q(3, x);
+/// assert_eq!(legendre_next(1, &x, &q1, &q0), q2);
+/// assert_eq!(legendre_next(2, &x, &q2, &q1), q3);
+/// ```
+///
+/// # See also
+///
+/// - [`legendre_p`]
+/// - [`legendre_assoc_next`]
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn legendre_next(n: u32, x: &f64, Pn: &f64, Pn_1: &f64) -> f64 {
+    legendre_assoc_next(n, 0, x, Pn, Pn_1)
+}
+
+/// Recurrence relation for [`legendre_p_assoc`]
+///
+/// *(n-m+1)P<sub>n+1</sub><sup>m</sup>(x)
+/// = (2n+1)xP<sub>n</sub><sup>m</sup>(x) - (n+m)P<sub>n-1</sub><sup>m</sup>(x)*
+///
+/// # Examples
+///
+/// ```
+/// # use boost::math::{legendre_p_assoc, legendre_assoc_next};
+/// let m = 1;
+/// let x = 0.42;
+/// let p0 = legendre_p_assoc(0, m, x);
+/// let p1 = legendre_p_assoc(1, m, x);
+/// let p2 = legendre_p_assoc(2, m, x);
+/// let p3 = legendre_p_assoc(3, m, x);
+/// assert_eq!(legendre_assoc_next(1, m, &x, &p1, &p0), p2);
+/// assert_eq!(legendre_assoc_next(2, m, &x, &p2, &p1), p3);
+/// ```
+///
+/// # See also
+///
+/// - [`legendre_p_assoc`]
+/// - [`legendre_next`]
+#[allow(non_snake_case)]
+#[inline(always)]
+pub fn legendre_assoc_next(n: u32, m: i32, x: &f64, Pn: &f64, Pn_1: &f64) -> f64 {
+    let n = n as i32;
+    ((2 * n + 1) as f64 * x * Pn - (n + m) as f64 * Pn_1) / ((n - m + 1) as f64)
 }
 
 #[cfg(test)]

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -145,8 +145,8 @@ double math_cos_pi(double x) { return boost::math::cos_pi(x); }
 
 // boost/math/special_functions/erf.hpp
 double math_erf(double x) { return boost::math::erf(x); }
-double math_erfc(double x) { return boost::math::erfc(x); }
 double math_erf_inv(double p) { return erf_inv(p); }
+double math_erfc(double x) { return boost::math::erfc(x); }
 double math_erfc_inv(double q) { return erfc_inv(q); }
 
 // boost/math/special_functions/expm1.hpp


### PR DESCRIPTION
This adds the following functions to `boost::math`:

- `chebyshev_next(&x, &Tn, &Tn_1)`
- `legendre_next(n, &x, &Pn, &Pn_1)`
- `legendre_assoc_next(n, m, &x, &Pn, &Pn_1)`
- `laguerre_next(n, m, &x, &Ln, &Ln_1)`
- `laguerre_assoc_next(n, m, &x, &Ln, &Ln_1)`
- `hermite_next(n, &x, &Hn, &Hn_1)`
