### PR TITLE
Airy functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ include = [
   "subprojects/boost_math/math/include/boost/math/policies",
   #
   "subprojects/boost_math/math/include/boost/math/special_functions",
-  "!subprojects/boost_math/math/include/boost/math/special_functions/detail/airy_ai_bi_zero.hpp",
   "!subprojects/boost_math/math/include/boost/math/special_functions/detail/bernoulli_details.hpp",
   "!subprojects/boost_math/math/include/boost/math/special_functions/detail/daubechies_scaling_integer_grid.hpp",
   "!subprojects/boost_math/math/include/boost/math/special_functions/detail/lanczos_sse2.hpp",

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,6 +6,14 @@ unsafe extern "C" {
     // boost/math/ccmath/sqrt.hpp
     pub fn math_ccmath_sqrt(x: f64) -> f64;
 
+    // boost/math/special_functions/airy.hpp
+    pub fn math_airy_ai(x: f64) -> f64;
+    pub fn math_airy_ai_prime(x: f64) -> f64;
+    pub fn math_airy_ai_zero(m: c_int) -> f64;
+    pub fn math_airy_bi(x: f64) -> f64;
+    pub fn math_airy_bi_prime(x: f64) -> f64;
+    pub fn math_airy_bi_zero(m: c_int) -> f64;
+
     // boost/math/special_functions/bessel.hpp
     pub fn math_cyl_bessel_j(nu: f64, x: f64) -> f64;
     pub fn math_cyl_neumann(nu: f64, x: f64) -> f64;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -126,14 +126,19 @@
 //! - [ ] Cyclic Hankel Functions
 //! - [ ] Spherical Hankel Functions
 //!
-//! <h4>Airy Functions</h4>
+//! ### Airy Functions
 //!
-//! - [ ] Airy *Ai* Function
-//! - [ ] Airy *Bi* Function
-//! - [ ] Airy *Ai'* Function
-//! - [ ] Airy *Bi'* Function
-//! - [ ] Finding Zeros of Airy Functions
-//!
+//! - [x] Airy *Ai* Function
+//!   - [`airy_ai`]
+//! - [x] Airy *Bi* Function
+//!   - [`airy_bi`]
+//! - [x] Airy *Ai'* Function
+//!   - [`airy_ai_prime`]
+//! - [x] Airy *Bi'* Function
+//!   - [`airy_bi_prime`]
+//! - [x] Finding Zeros of Airy Functions
+//!   - [`airy_ai_zero`]
+//!   - [`airy_bi_zero`]
 //! <h4>Elliptic Integrals</h4>
 //!
 //! - [ ] Elliptic Integrals - Carlson Form
@@ -234,6 +239,7 @@
 pub mod ccmath;
 mod special_functions;
 
+pub use special_functions::airy::*;
 pub use special_functions::bessel::*;
 pub use special_functions::beta::*;
 pub use special_functions::binomial::*;

--- a/src/math/special_functions/airy.rs
+++ b/src/math/special_functions/airy.rs
@@ -1,0 +1,102 @@
+//! boost/math/special_functions/airy.hpp
+//!
+//! TODO:
+//! - Support for `Range` in zero functions
+
+use crate::ffi;
+use core::ffi::c_int;
+
+/// Airy function *Ai(x)*
+///
+/// Corresponds to `boost::math::airy_ai(x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/ai.html>
+pub fn airy_ai(x: f64) -> f64 {
+    unsafe { ffi::math_airy_ai(x) }
+}
+
+/// Derivative of [`airy_ai`]
+///
+/// Corresponds to `boost::math::airy_ai_prime(x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/aip.html>
+pub fn airy_ai_prime(x: f64) -> f64 {
+    unsafe { ffi::math_airy_ai_prime(x) }
+}
+
+/// The *k*<sup>th</sup> zero of [`airy_ai`]
+///
+/// Zero-based indexing: `airy_ai_zero(0)` is the first zero.
+///
+/// Corresponds to `boost::math::airy_ai_zero(n)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/ai.html>
+pub fn airy_ai_zero(k: u32) -> f64 {
+    // The +1 is because Boost uses 1-based indexing
+    unsafe { ffi::math_airy_ai_zero(k as c_int + 1) }
+}
+
+/// Airy function *Bi(x)*
+///
+/// Corresponds to `boost::math::airy_bi(x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/bi.html>
+pub fn airy_bi(x: f64) -> f64 {
+    unsafe { ffi::math_airy_bi(x) }
+}
+
+/// Derivative of [`airy_bi`]
+///
+/// Corresponds to `boost::math::airy_bi_prime(x)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/bip.html>
+pub fn airy_bi_prime(x: f64) -> f64 {
+    unsafe { ffi::math_airy_bi_prime(x) }
+}
+
+/// The *k*<sup>th</sup> zero of [`airy_bi`]
+///
+/// Zero-based indexing: `airy_bi_zero(0)` is the first zero.
+///
+/// Corresponds to `boost::math::airy_bi_zero(n)` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/bi.html>
+pub fn airy_bi_zero(k: u32) -> f64 {
+    // The +1 is because Boost uses 1-based indexing
+    unsafe { ffi::math_airy_bi_zero(k as c_int + 1) }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::math::{airy_ai, airy_ai_prime, airy_ai_zero, airy_bi, airy_bi_prime, airy_bi_zero};
+
+    const RTOL: f64 = 5e-16;
+
+    // values from Wolfram Alpha
+
+    #[test]
+    fn test_airy_ai() {
+        assert_relative_eq!(airy_ai(0.0), 0.355_028_053_887_817_2, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_airy_ai_prime() {
+        assert_relative_eq!(airy_ai_prime(0.0), -0.258_819_403_792_806_8, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_airy_ai_zero() {
+        assert_relative_eq!(airy_ai_zero(0), -2.338_107_410_459_767, epsilon = RTOL);
+        assert_relative_eq!(airy_ai_zero(1), -4.087_949_444_130_97, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_airy_bi() {
+        assert_relative_eq!(airy_bi(0.0), 0.614_926_627_446_000_7, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_airy_bi_prime() {
+        assert_relative_eq!(airy_bi_prime(0.0), 0.448_288_357_353_826_4, epsilon = RTOL);
+    }
+
+    #[test]
+    fn test_airy_bi_zero() {
+        assert_relative_eq!(airy_bi_zero(0), -1.173_713_222_709_128, epsilon = RTOL);
+        assert_relative_eq!(airy_bi_zero(1), -3.271_093_302_836_353, epsilon = RTOL);
+    }
+}

--- a/src/math/special_functions/airy.rs
+++ b/src/math/special_functions/airy.rs
@@ -30,7 +30,7 @@ pub fn airy_ai_prime(x: f64) -> f64 {
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/ai.html>
 pub fn airy_ai_zero(k: u32) -> f64 {
     // The +1 is because Boost uses 1-based indexing
-    unsafe { ffi::math_airy_ai_zero(k as c_int + 1) }
+    unsafe { ffi::math_airy_ai_zero((k + 1) as c_int) }
 }
 
 /// Airy function *Bi(x)*
@@ -57,7 +57,7 @@ pub fn airy_bi_prime(x: f64) -> f64 {
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/airy/bi.html>
 pub fn airy_bi_zero(k: u32) -> f64 {
     // The +1 is because Boost uses 1-based indexing
-    unsafe { ffi::math_airy_bi_zero(k as c_int + 1) }
+    unsafe { ffi::math_airy_bi_zero((k + 1) as c_int) }
 }
 
 #[cfg(test)]

--- a/src/math/special_functions/mod.rs
+++ b/src/math/special_functions/mod.rs
@@ -1,3 +1,4 @@
+pub mod airy;
 pub mod bessel;
 pub mod beta;
 pub mod binomial;

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/math/ccmath/sqrt.hpp>
 
+#include <boost/math/special_functions/airy.hpp>
 #include <boost/math/special_functions/bessel.hpp>
 #include <boost/math/special_functions/beta.hpp>
 #include <boost/math/special_functions/binomial.hpp>
@@ -115,6 +116,14 @@ double math_cyl_bessel_i(double nu, double x) { return cyl_bessel_i(nu, x); }
 double math_cyl_bessel_k(double nu, double x) { return cyl_bessel_k(nu, x); }
 double math_sph_bessel(unsigned n, double x) { return sph_bessel(n, x); }
 double math_sph_neumann(unsigned n, double x) { return sph_neumann(n, x); }
+
+// boost/math/special_functions/airy.hpp
+double math_airy_ai(double x) { return airy_ai(x); }
+double math_airy_ai_prime(double x) { return airy_ai_prime(x); }
+double math_airy_ai_zero(int m) { return airy_ai_zero<double>(m); }
+double math_airy_bi(double x) { return airy_bi(x); }
+double math_airy_bi_prime(double x) { return airy_bi_prime(x); }
+double math_airy_bi_zero(int m) { return airy_bi_zero<double>(m); }
 
 // boost/math/special_functions/beta.hpp
 double math_beta(double a, double b) { return beta(a, b); }


### PR DESCRIPTION
This adds the following functions to the `boost::math` namespace:

- `airy_ai(x)`
- `airy_ai_prime(x)`
- `airy_ai_zero(k)`
- `airy_bi(x)`
- `airy_bi_prime(x)`
- `airy_bi_zero(k)`