### PR TITLE
Bessel function derivatives and improved Bessel docs

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -23,13 +23,21 @@ unsafe extern "C" {
 
     // boost/math/special_functions/bessel.hpp
     pub fn math_cyl_bessel_j(nu: f64, x: f64) -> f64;
-    pub fn math_cyl_bessel_j_zero(nu: f64, k: c_int) -> f64;
     pub fn math_cyl_neumann(nu: f64, x: f64) -> f64;
-    pub fn math_cyl_neumann_zero(nu: f64, k: c_int) -> f64;
     pub fn math_cyl_bessel_i(nu: f64, x: f64) -> f64;
     pub fn math_cyl_bessel_k(nu: f64, x: f64) -> f64;
     pub fn math_sph_bessel(n: c_uint, x: f64) -> f64;
     pub fn math_sph_neumann(n: c_uint, x: f64) -> f64;
+    pub fn math_cyl_bessel_j_zero(nu: f64, k: c_int) -> f64;
+    pub fn math_cyl_neumann_zero(nu: f64, k: c_int) -> f64;
+
+    // boost/math/special_functions/bessel_prime.hpp
+    pub fn math_cyl_bessel_j_prime(nu: f64, x: f64) -> f64;
+    pub fn math_cyl_neumann_prime(nu: f64, x: f64) -> f64;
+    pub fn math_cyl_bessel_i_prime(nu: f64, x: f64) -> f64;
+    pub fn math_cyl_bessel_k_prime(nu: f64, x: f64) -> f64;
+    pub fn math_sph_bessel_prime(n: c_uint, x: f64) -> f64;
+    pub fn math_sph_neumann_prime(n: c_uint, x: f64) -> f64;
 
     // boost/math/special_functions/beta.hpp
     pub fn math_beta(a: f64, b: f64) -> f64;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -110,19 +110,26 @@
 //! - [ ] Cardinal B-splines
 //!
 //! ### Bessel Functions
-//! - [x] Bessel Functions
-//!   - [`cyl_bessel_j`]
-//!   - [`cyl_neumann`]
-//! - [x] Zeros of Bessel Functions
-//!   - [`cyl_bessel_j_zero`]
-//!   - [`cyl_neumann_zero`]
-//! - [x] Modified Bessel Functions
-//!   - [`cyl_bessel_i`]
-//!   - [`cyl_bessel_k`]
-//! - [x] Spherical Bessel Functions
-//!   - [`sph_bessel`]
-//!   - [`sph_neumann`]
-//! - [ ] Derivatives of Bessel Functions
+//!
+//! |                   Type | First Kind       | Second Kind      |
+//! | ---------------------: | ---------------- | ---------------- |
+//! |          Cyclic Bessel | [`cyl_bessel_j`] | [`cyl_neumann`]  |
+//! | Modified Cyclic Bessel | [`cyl_bessel_i`] | [`cyl_bessel_k`] |
+//! |       Spherical Bessel | [`sph_bessel`]   | [`sph_neumann`]  |
+//!
+//! #### Zeros
+//!
+//! |                   Type | First Kind            | Second Kind      |
+//! | ---------------------: | --------------------- | ---------------- |
+//! |          Cyclic Bessel | [`cyl_bessel_j_zero`] | [`cyl_neumann_zero`]  |
+//!
+//! #### Derivatives
+//!
+//! |                   Type | First Kind             | Second Kind            |
+//! | ---------------------: | ---------------------- | ---------------------- |
+//! |          Cyclic Bessel | [`cyl_bessel_j_prime`] | [`cyl_neumann_prime`]  |
+//! | Modified Cyclic Bessel | [`cyl_bessel_i_prime`] | [`cyl_bessel_k_prime`] |
+//! |       Spherical Bessel | [`sph_bessel_prime`]   | [`sph_neumann_prime`]  |
 //!
 //! <h4>Hankel Functions</h4>
 //!
@@ -248,6 +255,7 @@ pub use special_functions::airy::*;
 pub use special_functions::asinh::*;
 pub use special_functions::atanh::*;
 pub use special_functions::bessel::*;
+pub use special_functions::bessel_prime::*;
 pub use special_functions::beta::*;
 pub use special_functions::binomial::*;
 pub use special_functions::cbrt::*;

--- a/src/math/special_functions/bessel_prime.rs
+++ b/src/math/special_functions/bessel_prime.rs
@@ -1,0 +1,106 @@
+//! boost/math/special_functions/bessel_prime.hpp
+
+use crate::ffi;
+
+/// Derivative of [`cyl_bessel_j(x)`](crate::math::cyl_bessel_j)
+///
+/// *2 J'<sub>ν</sub>(x) = J<sub>ν-1</sub>(x) - J<sub>ν+1</sub>(x)*
+///
+/// Corresponds to `boost::math::cyl_bessel_j_prime` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/bessel/bessel_derivatives.html>
+pub fn cyl_bessel_j_prime(nu: f64, x: f64) -> f64 {
+    unsafe { ffi::math_cyl_bessel_j_prime(nu, x) }
+}
+
+/// Derivative of [`cyl_neumann(x)`](crate::math::cyl_neumann)
+///
+/// *2 Y'<sub>ν</sub>(x) = Y<sub>ν-1</sub>(x) - Y<sub>ν+1</sub>(x)*
+///
+/// Corresponds to `boost::math::cyl_neumann_prime` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/bessel/bessel_derivatives.html>
+#[doc(alias = "cyl_bessel_y_prime")]
+pub fn cyl_neumann_prime(nu: f64, x: f64) -> f64 {
+    unsafe { ffi::math_cyl_neumann_prime(nu, x) }
+}
+
+/// Derivative of [`cyl_bessel_i(x)`](crate::math::cyl_bessel_i)
+///
+/// *2 I'<sub>ν</sub>(x) = I<sub>ν-1</sub>(x) + I<sub>ν+1</sub>(x)*
+///
+/// Corresponds to `boost::math::cyl_bessel_i_prime` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/bessel/bessel_derivatives.html>
+pub fn cyl_bessel_i_prime(nu: f64, x: f64) -> f64 {
+    unsafe { ffi::math_cyl_bessel_i_prime(nu, x) }
+}
+
+/// Derivative of [`cyl_bessel_k(x)`](crate::math::cyl_bessel_k)
+///
+/// *-2 K'<sub>ν</sub>(x) = K<sub>ν-1</sub>(x) + K<sub>ν+1</sub>(x)*
+///
+/// Corresponds to `boost::math::cyl_bessel_k_prime` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/bessel/bessel_derivatives.html>
+pub fn cyl_bessel_k_prime(nu: f64, x: f64) -> f64 {
+    unsafe { ffi::math_cyl_bessel_k_prime(nu, x) }
+}
+
+/// Derivative of [`sph_bessel(n, x)`](crate::math::sph_bessel)
+///
+/// *j'<sub>n</sub>(x) = (n/x) j<sub>n</sub>(x) - j<sub>n+1</sub>(x)*
+///
+/// Corresponds to `boost::math::sph_bessel_prime` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/bessel/bessel_derivatives.html>
+#[doc(alias = "sph_bessel_j_prime")]
+pub fn sph_bessel_prime(n: u32, x: f64) -> f64 {
+    unsafe { ffi::math_sph_bessel_prime(n, x) }
+}
+
+/// Derivative of [`sph_neumann(n, x)`](crate::math::sph_neumann)
+///
+/// *y'<sub>n</sub>(x) = (n/x) y<sub>n</sub>(x) - y<sub>n+1</sub>(x)*
+///
+/// Corresponds to `boost::math::sph_neumann_prime` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/bessel/bessel_derivatives.html>
+#[doc(alias = "sph_bessel_y_prime")]
+pub fn sph_neumann_prime(n: u32, x: f64) -> f64 {
+    unsafe { ffi::math_sph_neumann_prime(n, x) }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::math::{
+        cyl_bessel_i_prime, cyl_bessel_j_prime, cyl_bessel_k_prime, cyl_neumann_prime,
+        sph_bessel_prime, sph_neumann_prime,
+    };
+
+    // values from Wolfram Alpha
+
+    #[test]
+    fn test_cyl_bessel_j_prime() {
+        assert_relative_eq!(cyl_bessel_j_prime(0.0, 1.0), -0.440_050_585_744_933_5);
+    }
+
+    #[test]
+    fn test_cyl_neumann_prime() {
+        assert_relative_eq!(cyl_neumann_prime(0.0, 1.0), 0.781_212_821_300_288_7);
+    }
+
+    #[test]
+    fn test_cyl_bessel_i_prime() {
+        assert_relative_eq!(cyl_bessel_i_prime(0.0, 1.0), 0.565_159_103_992_485);
+    }
+
+    #[test]
+    fn test_cyl_bessel_k_prime() {
+        assert_relative_eq!(cyl_bessel_k_prime(0.0, 1.0), -0.601_907_230_197_234_6);
+    }
+
+    #[test]
+    fn test_sph_bessel_prime() {
+        assert_relative_eq!(sph_bessel_prime(0, 1.0), -0.301_168_678_939_756_8);
+    }
+
+    #[test]
+    fn test_sph_neumann_prime() {
+        assert_relative_eq!(sph_neumann_prime(0, 1.0), 1.381_773_290_676_036_3);
+    }
+}

--- a/src/math/special_functions/bessel_prime.rs
+++ b/src/math/special_functions/bessel_prime.rs
@@ -72,35 +72,45 @@ mod tests {
         sph_bessel_prime, sph_neumann_prime,
     };
 
+    const EPS: f64 = 1e-15;
+
     // values from Wolfram Alpha
 
     #[test]
     fn test_cyl_bessel_j_prime() {
-        assert_relative_eq!(cyl_bessel_j_prime(0.0, 1.0), -0.440_050_585_744_933_5);
+        assert_abs_diff_eq!(cyl_bessel_j_prime(0.0, 1.0), -0.440_050_585_744_933_5);
     }
 
     #[test]
     fn test_cyl_neumann_prime() {
-        assert_relative_eq!(cyl_neumann_prime(0.0, 1.0), 0.781_212_821_300_288_7);
+        assert_abs_diff_eq!(cyl_neumann_prime(0.0, 1.0), 0.781_212_821_300_288_7);
     }
 
     #[test]
     fn test_cyl_bessel_i_prime() {
-        assert_relative_eq!(cyl_bessel_i_prime(0.0, 1.0), 0.565_159_103_992_485);
+        assert_abs_diff_eq!(cyl_bessel_i_prime(0.0, 1.0), 0.565_159_103_992_485);
     }
 
     #[test]
     fn test_cyl_bessel_k_prime() {
-        assert_relative_eq!(cyl_bessel_k_prime(0.0, 1.0), -0.601_907_230_197_234_6);
+        assert_abs_diff_eq!(cyl_bessel_k_prime(0.0, 1.0), -0.601_907_230_197_234_6);
     }
 
     #[test]
     fn test_sph_bessel_prime() {
-        assert_relative_eq!(sph_bessel_prime(0, 1.0), -0.301_168_678_939_756_8);
+        assert_abs_diff_eq!(
+            sph_bessel_prime(0, 1.0),
+            -0.301_168_678_939_756_8,
+            epsilon = EPS,
+        );
     }
 
     #[test]
     fn test_sph_neumann_prime() {
-        assert_relative_eq!(sph_neumann_prime(0, 1.0), 1.381_773_290_676_036_3);
+        assert_abs_diff_eq!(
+            sph_neumann_prime(0, 1.0),
+            1.381_773_290_676_036_3,
+            epsilon = EPS,
+        );
     }
 }

--- a/src/math/special_functions/mod.rs
+++ b/src/math/special_functions/mod.rs
@@ -3,6 +3,7 @@ pub mod airy;
 pub mod asinh;
 pub mod atanh;
 pub mod bessel;
+pub mod bessel_prime;
 pub mod beta;
 pub mod binomial;
 pub mod cbrt;

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -24,6 +24,7 @@
 #include <boost/math/special_functions/asinh.hpp>
 #include <boost/math/special_functions/atanh.hpp>
 #include <boost/math/special_functions/bessel.hpp>
+#include <boost/math/special_functions/bessel_prime.hpp>
 #include <boost/math/special_functions/beta.hpp>
 #include <boost/math/special_functions/binomial.hpp>
 #include <boost/math/special_functions/cbrt.hpp>
@@ -129,13 +130,21 @@ double math_airy_bi_zero(int m) { return airy_bi_zero<double>(m); }
 
 // boost/math/special_functions/bessel.hpp
 double math_cyl_bessel_j(double nu, double x) { return cyl_bessel_j(nu, x); }
-double math_cyl_bessel_j_zero(double nu, int k) { return cyl_bessel_j_zero(nu, k); }
 double math_cyl_neumann(double nu, double x) { return cyl_neumann(nu, x); }
-double math_cyl_neumann_zero(double nu, int k) { return cyl_neumann_zero(nu, k); }
 double math_cyl_bessel_i(double nu, double x) { return cyl_bessel_i(nu, x); }
 double math_cyl_bessel_k(double nu, double x) { return cyl_bessel_k(nu, x); }
 double math_sph_bessel(unsigned n, double x) { return sph_bessel(n, x); }
 double math_sph_neumann(unsigned n, double x) { return sph_neumann(n, x); }
+double math_cyl_bessel_j_zero(double nu, int k) { return cyl_bessel_j_zero(nu, k); }
+double math_cyl_neumann_zero(double nu, int k) { return cyl_neumann_zero(nu, k); }
+
+// boost/math/special_functions/bessel_prime.hpp
+double math_cyl_bessel_j_prime(double nu, double x) { return cyl_bessel_j_prime(nu, x); }
+double math_cyl_neumann_prime(double nu, double x) { return cyl_neumann_prime(nu, x); }
+double math_cyl_bessel_i_prime(double nu, double x) { return cyl_bessel_i_prime(nu, x); }
+double math_cyl_bessel_k_prime(double nu, double x) { return cyl_bessel_k_prime(nu, x); }
+double math_sph_bessel_prime(unsigned n, double x) { return sph_bessel_prime(n, x); }
+double math_sph_neumann_prime(unsigned n, double x) { return sph_neumann_prime(n, x); }
 
 // boost/math/special_functions/beta.hpp
 double math_beta(double a, double b) { return beta(a, b); }


### PR DESCRIPTION
This adds the following functions to the `boost::math` namespace:

- `cyl_bessel_j_prime`
- `cyl_neumann_prime`
- `cyl_bessel_i_prime`
- `cyl_bessel_k_prime`
- `sph_bessel_prime`
- `sph_neumann_prime`