### PR TITLE
Carlson's Elliptic Integrals

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -70,6 +70,17 @@ unsafe extern "C" {
     // boost/math/special_functions/digamma.hpp
     pub(crate) fn math_digamma(x: f64) -> f64;
 
+    // boost/math/special_functions/ellint_rc.hpp
+    pub(crate) fn math_ellint_rc(x: f64, y: f64) -> f64;
+    // boost/math/special_functions/ellint_rd.hpp
+    pub(crate) fn math_ellint_rd(x: f64, y: f64, z: f64) -> f64;
+    // boost/math/special_functions/ellint_rf.hpp
+    pub(crate) fn math_ellint_rf(x: f64, y: f64, z: f64) -> f64;
+    // boost/math/special_functions/ellint_rg.hpp
+    pub(crate) fn math_ellint_rg(x: f64, y: f64, z: f64) -> f64;
+    // boost/math/special_functions/ellint_rj.hpp
+    pub(crate) fn math_ellint_rj(x: f64, y: f64, z: f64, p: f64) -> f64;
+
     // boost/math/special_functions/erf.hpp
     pub(crate) fn math_erf(x: f64) -> f64;
     pub(crate) fn math_erfc(x: f64) -> f64;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -148,7 +148,7 @@
 //! | *Ai*     | [`airy_ai`] | [`airy_ai_prime`] | [`airy_ai_zero`] |
 //! | *Bi*     | [`airy_bi`] | [`airy_bi_prime`] | [`airy_bi_zero`] |
 //!
-//! <h4>Elliptic Integrals</h4>
+//! ### Elliptic Integrals
 //!
 //! - [x] Elliptic Integrals - Carlson Form
 //!   - [`ellint_rc`](ellint_rc) - *R<sub>C</sub>(x,y)*

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -150,7 +150,12 @@
 //!
 //! <h4>Elliptic Integrals</h4>
 //!
-//! - [ ] Elliptic Integrals - Carlson Form
+//! - [x] Elliptic Integrals - Carlson Form
+//!   - [`ellint_rc`](ellint_rc) - *R<sub>C</sub>(x,y)*
+//!   - [`ellint_rd`](ellint_rd) - *R<sub>D</sub>(x,y,z)*
+//!   - [`ellint_rf`](ellint_rf) - *R<sub>F</sub>(x,y,z)*
+//!   - [`ellint_rg`](ellint_rg) - *R<sub>G</sub>(x,y,z)*
+//!   - [`ellint_rj`](ellint_rj) - *R<sub>J</sub>(x,y,z,p)*
 //! - [ ] Elliptic Integrals of the First Kind - Legendre Form
 //! - [ ] Elliptic Integrals of the Second Kind - Legendre Form
 //! - [ ] Elliptic Integrals of the Third Kind - Legendre Form
@@ -261,6 +266,7 @@ pub use special_functions::cbrt::*;
 pub use special_functions::chebyshev::*;
 pub use special_functions::cos_pi::*;
 pub use special_functions::digamma::*;
+pub use special_functions::ellint_r::*;
 pub use special_functions::erf::*;
 pub use special_functions::expint::*;
 pub use special_functions::expm1::*;

--- a/src/math/special_functions/ellint_r.rs
+++ b/src/math/special_functions/ellint_r.rs
@@ -1,0 +1,95 @@
+//! Carlson Elliptic Integrals
+//! boost/math/special_functions/ellint_rc.hpp
+//! boost/math/special_functions/ellint_rd.hpp
+//! boost/math/special_functions/ellint_rf.hpp
+//! boost/math/special_functions/ellint_rg.hpp
+//! boost/math/special_functions/ellint_rj.hpp
+
+use crate::ffi;
+
+/// Carlson's elliptic integral *R<sub>C</sub>(x,y)*.
+///
+/// Requires that *x > 0* and *y ≠ 0*.
+///
+/// Corresponds to `boost::math::ellint_rc` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/ellint/ellint_carlson.html>
+pub fn ellint_rc(x: f64, y: f64) -> f64 {
+    unsafe { ffi::math_ellint_rc(x, y) }
+}
+
+/// Carlson's elliptic integral *R<sub>D</sub>(x,y,z)*.
+///
+/// Requires that *x,y,z ≥ 0* and *x+y > 0*.
+///
+/// Corresponds to `boost::math::ellint_rd` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/ellint/ellint_carlson.html>
+pub fn ellint_rd(x: f64, y: f64, z: f64) -> f64 {
+    unsafe { ffi::math_ellint_rd(x, y, z) }
+}
+
+/// Carlson's elliptic integral *R<sub>F</sub>(x,y,z)*.
+///
+/// Requires that *x,y,z ≥ 0* and at most one of *x,y,z* is zero.
+///
+/// Corresponds to `boost::math::ellint_rf` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/ellint/ellint_carlson.html>
+pub fn ellint_rf(x: f64, y: f64, z: f64) -> f64 {
+    unsafe { ffi::math_ellint_rf(x, y, z) }
+}
+
+/// Carlson's elliptic integral *R<sub>G</sub>(x,y,z)*.
+///
+/// Requires that *x,y ≥ 0*.
+///
+/// Corresponds to `boost::math::ellint_rg` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/ellint/ellint_carlson.html>
+pub fn ellint_rg(x: f64, y: f64, z: f64) -> f64 {
+    unsafe { ffi::math_ellint_rg(x, y, z) }
+}
+
+/// Carlson's elliptic integral *R<sub>J</sub>(x,y,z,p)*.
+///
+/// Requires that *x,y,z ≥ 0*, *p>0*, and at most one of *x,y,z* is zero.
+///
+/// Corresponds to `boost::math::ellint_rj` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/ellint/ellint_carlson.html>
+pub fn ellint_rj(x: f64, y: f64, z: f64, p: f64) -> f64 {
+    unsafe { ffi::math_ellint_rj(x, y, z, p) }
+}
+
+#[cfg(test)]
+mod smoketests {
+    use crate::math::{ellint_rc, ellint_rd, ellint_rf, ellint_rg, ellint_rj};
+
+    #[test]
+    fn test_ellint_rc() {
+        assert!(ellint_rc(0.0, 0.0).is_nan());
+        assert!(ellint_rc(1.0, 2.0).is_finite());
+    }
+
+    #[test]
+    fn test_ellint_rd() {
+        assert!(ellint_rd(0.0, 0.0, 0.0).is_nan());
+        assert!(ellint_rd(1.0, 2.0, 3.0).is_finite());
+    }
+
+    #[test]
+    fn test_ellint_rf() {
+        assert!(ellint_rf(0.0, 0.0, 0.0).is_nan());
+        assert!(ellint_rf(1.0, 2.0, 3.0).is_finite());
+    }
+
+    #[test]
+    fn test_ellint_rg() {
+        assert!(ellint_rg(-1.0, 0.0, 0.0).is_nan());
+        assert!(ellint_rg(0.0, -1.0, 0.0).is_nan());
+        assert!(ellint_rg(0.0, 0.0, 0.0).is_finite());
+        assert!(ellint_rg(1.0, 2.0, 3.0).is_finite());
+    }
+
+    #[test]
+    fn test_ellint_rj() {
+        assert!(ellint_rj(0.0, 0.0, 0.0, 0.0).is_nan());
+        assert!(ellint_rj(1.0, 2.0, 3.0, 4.0).is_finite());
+    }
+}

--- a/src/math/special_functions/mod.rs
+++ b/src/math/special_functions/mod.rs
@@ -11,6 +11,7 @@ pub(super) mod cbrt;
 pub(super) mod chebyshev;
 pub(super) mod cos_pi;
 pub(super) mod digamma;
+pub(super) mod ellint_r;
 pub(super) mod erf;
 pub(super) mod expint;
 pub(super) mod expm1;

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -30,6 +30,11 @@
 #include <boost/math/special_functions/cbrt.hpp>
 #include <boost/math/special_functions/chebyshev.hpp>
 #include <boost/math/special_functions/cos_pi.hpp>
+#include <boost/math/special_functions/ellint_rc.hpp>
+#include <boost/math/special_functions/ellint_rd.hpp>
+#include <boost/math/special_functions/ellint_rf.hpp>
+#include <boost/math/special_functions/ellint_rg.hpp>
+#include <boost/math/special_functions/ellint_rj.hpp>
 #include <boost/math/special_functions/erf.hpp>
 #include <boost/math/special_functions/expint.hpp>
 #include <boost/math/special_functions/expm1.hpp>
@@ -178,6 +183,17 @@ double math_chebyshev_u(unsigned n, double x) { return chebyshev_u(n, x); }
 
 // boost/math/special_functions/cos_pi.hpp
 double math_cos_pi(double x) { return boost::math::cos_pi(x); }
+
+// boost/math/special_functions/ellint_rc.hpp
+double math_ellint_rc(double x, double y) { return ellint_rc(x, y); }
+// boost/math/special_functions/ellint_rd.hpp
+double math_ellint_rd(double x, double y, double z) { return ellint_rd(x, y, z); }
+// boost/math/special_functions/ellint_rf.hpp
+double math_ellint_rf(double x, double y, double z) { return ellint_rf(x, y, z); }
+// boost/math/special_functions/ellint_rg.hpp
+double math_ellint_rg(double x, double y, double z) { return ellint_rg(x, y, z); }
+// boost/math/special_functions/ellint_rj.hpp
+double math_ellint_rj(double x, double y, double z, double p) { return ellint_rj(x, y, z, p); }
 
 // boost/math/special_functions/erf.hpp
 double math_erf(double x) { return boost::math::erf(x); }


### PR DESCRIPTION
This adds the following public elliptic functions to the `boost::math` namespace:

- `ellip_rc(x, y)`
- `ellip_rd(x, y, z)`
- `ellip_rf(x, y, z)`
- `ellip_rg(x, y, z)`
- `ellip_rj(x, y, z, p)`