### PR TITLE
Jacobi Zeta and Heuman Lambda elliptic integrals

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -139,6 +139,9 @@ unsafe extern "C" {
     // boost/math/special_functions/hermite.hpp
     pub(crate) fn math_hermite(n: c_uint, x: f64) -> f64;
 
+    // boost/math/special_functions/heuman_lambda.hpp
+    pub(crate) fn math_heuman_lambda(k: f64, phi: f64) -> f64;
+
     // boost/math/special_functions/hypergeometric_0F1.hpp
     pub(crate) fn math_hypergeometric_0F1(b: f64, x: f64) -> f64;
     // boost/math/special_functions/hypergeometric_1F0.hpp
@@ -162,6 +165,9 @@ unsafe extern "C" {
         x: f64,
         k: c_uint,
     ) -> f64;
+
+    // boost/math/special_functions/jacobi_zeta.hpp
+    pub(crate) fn math_jacobi_zeta(k: f64, phi: f64) -> f64;
 
     // boost/math/special_functions/laguerre.hpp
     pub(crate) fn math_laguerre(n: c_uint, x: f64) -> f64;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -150,26 +150,28 @@
 //!
 //! ### Elliptic Integrals
 //!
-//! - [x] Elliptic Integrals - Carlson Form
+//! - Elliptic Integrals - Carlson Form
 //!   - [`ellint_rc`] - *R<sub>C</sub>(x,y)*
 //!   - [`ellint_rd`] - *R<sub>D</sub>(x,y,z)*
 //!   - [`ellint_rf`] - *R<sub>F</sub>(x,y,z)*
 //!   - [`ellint_rg`] - *R<sub>G</sub>(x,y,z)*
 //!   - [`ellint_rj`] - *R<sub>J</sub>(x,y,z,p)*
-//! - [x] Elliptic Integrals of the First Kind - Legendre Form
+//! - Elliptic Integrals of the First Kind - Legendre Form
 //!   - [`ellint_1`] - *K(k)*
 //!   - [`ellint_1_inc`] - *F(φ,k)*
-//! - [x] Elliptic Integrals of the Second Kind - Legendre Form
+//! - Elliptic Integrals of the Second Kind - Legendre Form
 //!   - [`ellint_2`] - *E(k)*
 //!   - [`ellint_2_inc`] - *E(φ,k)*
-//! - [x] Elliptic Integrals of the Third Kind - Legendre Form
+//! - Elliptic Integrals of the Third Kind - Legendre Form
 //!   - [`ellint_3`] - *Π(v,k)*
 //!   - [`ellint_3_inc`] - *Π(v,φ,k)*
-//! - [x] Elliptic Integral *D* - Legendre Form
+//! - Elliptic Integral *D* - Legendre Form
 //!   - [`ellint_d`] - *D(k)*
 //!   - [`ellint_d_inc`] - *D(φ,k)*
-//! - [ ] Jacobi Zeta Function
-//! - [ ] Heuman Lambda Function
+//! - Jacobi Zeta Function
+//!   - [`jacobi_zeta`] - *Z(φ,k)*
+//! - Heuman Lambda Function
+//!   - [`heuman_lambda`] - *Λ<sub>0</sub>(φ,k)*
 //!
 //! <h4>Jacobi Elliptic Functions</h4>
 //!
@@ -288,9 +290,11 @@ pub use special_functions::gegenbauer::*;
 #[cfg(feature = "num-complex")]
 pub use special_functions::hankel::*;
 pub use special_functions::hermite::*;
+pub use special_functions::heuman_lambda::*;
 pub use special_functions::hypergeometric::*;
 pub use special_functions::hypot::*;
 pub use special_functions::jacobi::*;
+pub use special_functions::jacobi_zeta::*;
 pub use special_functions::laguerre::*;
 pub use special_functions::lambert_w::*;
 pub use special_functions::legendre::*;

--- a/src/math/special_functions/heuman_lambda.rs
+++ b/src/math/special_functions/heuman_lambda.rs
@@ -1,0 +1,21 @@
+//! boost/math/special_functions/heuman_lambda.hpp
+
+use crate::ffi;
+
+/// Heuman's Lambda function *Λ<sub>0</sub>(φ,k)*
+///
+/// Corresponds to `boost::math::heuman_lambda` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/ellint/heuman_lambda.html>
+pub fn heuman_lambda(k: f64, phi: f64) -> f64 {
+    unsafe { ffi::math_heuman_lambda(k, phi) }
+}
+
+#[cfg(test)]
+mod smoketests {
+    use crate::math::heuman_lambda;
+
+    #[test]
+    fn test_heuman_lambda() {
+        assert!(heuman_lambda(0.5, 1.0).is_finite());
+    }
+}

--- a/src/math/special_functions/jacobi_zeta.rs
+++ b/src/math/special_functions/jacobi_zeta.rs
@@ -1,0 +1,21 @@
+//! boost/math/special_functions/jacobi_zeta.hpp
+
+use crate::ffi;
+
+/// Jacobi's Zeta function *Z(φ,m)*.
+///
+/// Corresponds to `boost::math::jacobi_zeta` in C++.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/ellint/jacobi_zeta.html>
+pub fn jacobi_zeta(k: f64, phi: f64) -> f64 {
+    unsafe { ffi::math_jacobi_zeta(k, phi) }
+}
+
+#[cfg(test)]
+mod smoketests {
+    use crate::math::jacobi_zeta;
+
+    #[test]
+    fn test_jacobi_zeta() {
+        assert!(jacobi_zeta(0.5, 1.0).is_finite());
+    }
+}

--- a/src/math/special_functions/mod.rs
+++ b/src/math/special_functions/mod.rs
@@ -25,9 +25,11 @@ pub(super) mod gegenbauer;
 #[cfg(feature = "num-complex")]
 pub(super) mod hankel;
 pub(super) mod hermite;
+pub(super) mod heuman_lambda;
 pub(super) mod hypergeometric;
 pub(super) mod hypot;
 pub(super) mod jacobi;
+pub(super) mod jacobi_zeta;
 pub(super) mod laguerre;
 pub(super) mod lambert_w;
 pub(super) mod legendre;

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -47,12 +47,14 @@
 #include <boost/math/special_functions/gegenbauer.hpp>
 #include <boost/math/special_functions/hankel.hpp>
 #include <boost/math/special_functions/hermite.hpp>
+#include <boost/math/special_functions/heuman_lambda.hpp>
 #include <boost/math/special_functions/hypergeometric_0F1.hpp>
 #include <boost/math/special_functions/hypergeometric_1F0.hpp>
 #include <boost/math/special_functions/hypergeometric_1F1.hpp>
 #include <boost/math/special_functions/hypergeometric_2F0.hpp>
 #include <boost/math/special_functions/hypot.hpp>
 #include <boost/math/special_functions/jacobi.hpp>
+#include <boost/math/special_functions/jacobi_zeta.hpp>
 #include <boost/math/special_functions/laguerre.hpp>
 #include <boost/math/special_functions/lambert_w.hpp>
 #include <boost/math/special_functions/legendre.hpp>
@@ -277,6 +279,9 @@ void math_sph_hankel_2(double nu, double x, double* out_re, double* out_im) {
 // boost/math/special_functions/hermite.hpp
 double math_hermite(unsigned n, double x) { return hermite(n, x); }
 
+// boost/math/special_functions/heuman_lambda.hpp
+double math_heuman_lambda(double k, double phi) { return heuman_lambda(k, phi); }
+
 // boost/math/special_functions/hypergeometric_0F1.hpp
 double math_hypergeometric_0F1(double b, double x) { return hypergeometric_0F1(b, x); }
 
@@ -307,6 +312,9 @@ double math_jacobi(unsigned n, double alpha, double beta, double x) {
 double math_jacobi_derivative(unsigned n, double alpha, double beta, double x, unsigned k) {
     return jacobi_derivative(n, alpha, beta, x, k);
 }
+
+// boost/math/special_functions/jacobi_zeta.hpp
+double math_jacobi_zeta(double k, double phi) { return jacobi_zeta(k, phi); }
 
 // boost/math/special_functions/laguerre.hpp
 double math_laguerre(unsigned n, double x) { return laguerre(n, x); }


### PR DESCRIPTION
This adds the following public functions to the `boost::math` namespace

- `jacobi_zeta(k, phi)`
- `heuman_lambda(k, phi)`

