### PR TITLE
Improved orthogonal polynomials

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -137,6 +137,7 @@ unsafe extern "C" {
     pub(crate) fn math_gegenbauer_derivative(n: c_uint, lambda: f64, x: f64, k: c_uint) -> f64;
 
     // boost/math/special_functions/hermite.hpp
+    #[cfg(test)]
     pub(crate) fn math_hermite(n: c_uint, x: f64) -> f64;
 
     // boost/math/special_functions/heuman_lambda.hpp

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -99,6 +99,8 @@
 //! - Hermite Polynomials
 //!   - [`hermite_h`]
 //!   - [`hermite_h_next`]
+//!   - [`hermite_he`]
+//!   - [`hermite_he_next`]
 //! - Gegenbauer Polynomials
 //!   - [`gegenbauer`]
 //!   - [`gegenbauer_derivative`]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -97,8 +97,8 @@
 //!   - [`laguerre_assoc`]
 //!   - [`laguerre_assoc_next`]
 //! - Hermite Polynomials
-//!   - [`hermite`]
-//!   - [`hermite_next`]
+//!   - [`hermite_h`]
+//!   - [`hermite_h_next`]
 //! - Gegenbauer Polynomials
 //!   - [`gegenbauer`]
 //!   - [`gegenbauer_derivative`]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -98,8 +98,10 @@
 //!   - [`laguerre_assoc_next`]
 //! - Hermite Polynomials
 //!   - [`hermite_h`]
+//!   - [`hermite_h_derivative`]
 //!   - [`hermite_h_next`]
 //!   - [`hermite_he`]
+//!   - [`hermite_he_derivative`]
 //!   - [`hermite_he_next`]
 //! - Gegenbauer Polynomials
 //!   - [`gegenbauer`]

--- a/src/math/special_functions/chebyshev.rs
+++ b/src/math/special_functions/chebyshev.rs
@@ -2,47 +2,6 @@
 
 use crate::ffi;
 
-/// Recurrence relation for Chebyshev polynomials
-///
-/// *T<sub>n+1</sub>(x) = 2 x T<sub>n</sub>(x) - T<sub>n-1</sub>(x)*
-///
-/// Note that this applies to both the first and second kinds.
-///
-/// # Examples
-///
-/// [`chebyshev_t`] recurrence:
-///
-/// ```
-/// # use approx::assert_relative_eq;
-/// # use boost::math::{chebyshev_t, chebyshev_next};
-/// let x = 0.42;
-/// let t0 = chebyshev_t(0, x); // 1
-/// let t1 = chebyshev_t(1, x); // x
-/// let t2 = chebyshev_t(2, x); // 2x² - 1
-/// let t3 = chebyshev_t(3, x); // 4x³ - 3x
-/// assert_relative_eq!(chebyshev_next(&x, &t1, &t0), t2);
-/// assert_relative_eq!(chebyshev_next(&x, &t2, &t1), t3);
-/// ```
-///
-/// [`chebyshev_u`] recurrence:
-///
-/// ```
-/// # use approx::assert_relative_eq;
-/// # use boost::math::{chebyshev_u, chebyshev_next};
-/// let x = 0.42;
-/// let u0 = chebyshev_u(0, x); // 1
-/// let u1 = chebyshev_u(1, x); // 2x
-/// let u2 = chebyshev_u(2, x); // 4x² - 1
-/// let u3 = chebyshev_u(3, x); // 8x³ - 4x
-/// assert_relative_eq!(chebyshev_next(&x, &u1, &u0), u2);
-/// assert_relative_eq!(chebyshev_next(&x, &u2, &u1), u3);
-/// ```
-#[allow(non_snake_case)]
-#[inline(always)]
-pub fn chebyshev_next(x: &f64, Tn: &f64, Tn_1: &f64) -> f64 {
-    2.0 * x * Tn - Tn_1
-}
-
 /// Chebyshev polynomial of the 1st kind T<sub>n</sub>(x).
 ///
 /// Defined as <i>T<sub>n</sub>(</i>cos<i>(θ)) = </i>cos<i>(n θ)</i>.
@@ -74,6 +33,49 @@ pub fn chebyshev_t_prime(n: u32, x: f64) -> f64 {
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/chebyshev.html>
 pub fn chebyshev_u(n: u32, x: f64) -> f64 {
     unsafe { ffi::math_chebyshev_u(n, x) }
+}
+
+/// Recurrence relation for Chebyshev polynomials
+///
+/// *T<sub>n+1</sub>(x) = 2 x T<sub>n</sub>(x) - T<sub>n-1</sub>(x)*
+///
+/// Note that this applies to both the first and second kinds.
+///
+/// # Examples
+///
+/// [`chebyshev_t`] recurrence:
+///
+/// ```
+/// # use approx::assert_relative_eq;
+/// # use boost::math::{chebyshev_t, chebyshev_next};
+/// let x = 0.42;
+/// let t0 = chebyshev_t(0, x); // 1
+/// let t1 = chebyshev_t(1, x); // x
+/// let t2 = chebyshev_t(2, x); // 2x² - 1
+/// let t3 = chebyshev_t(3, x); // 4x³ - 3x
+/// assert_relative_eq!(chebyshev_next(x, t1, t0), t2);
+/// assert_relative_eq!(chebyshev_next(x, t2, t1), t3);
+/// ```
+///
+/// [`chebyshev_u`] recurrence:
+///
+/// ```
+/// # use approx::assert_relative_eq;
+/// # use boost::math::{chebyshev_u, chebyshev_next};
+/// let x = 0.42;
+/// let u0 = chebyshev_u(0, x); // 1
+/// let u1 = chebyshev_u(1, x); // 2x
+/// let u2 = chebyshev_u(2, x); // 4x² - 1
+/// let u3 = chebyshev_u(3, x); // 8x³ - 4x
+/// assert_relative_eq!(chebyshev_next(x, u1, u0), u2);
+/// assert_relative_eq!(chebyshev_next(x, u2, u1), u3);
+/// ```
+#[inline(always)]
+#[allow(non_snake_case)]
+#[doc(alias = "chebyshev_t_next")]
+#[doc(alias = "chebyshev_u_next")]
+pub fn chebyshev_next(x: f64, Tn: f64, Tn_prev: f64) -> f64 {
+    2.0 * x * Tn - Tn_prev
 }
 
 #[cfg(test)]

--- a/src/math/special_functions/hermite.rs
+++ b/src/math/special_functions/hermite.rs
@@ -7,19 +7,39 @@
 /// # Examples
 ///
 /// ```
-/// # use boost::math::{hermite, hermite_next};
+/// # use boost::math::{hermite_h, hermite_h_next};
 /// let x = 0.42;
-/// let h0 = hermite(0, x); // 1
-/// let h1 = hermite(1, x); // 2x
-/// let h2 = hermite(2, x); // 4x² - 2
-/// let h3 = hermite(3, x); // 8x³ - 12x
-/// assert_eq!(hermite_next(1, x, h1, h0), h2);
-/// assert_eq!(hermite_next(2, x, h2, h1), h3);
+/// let p0 = hermite_h(0, x); // 1
+/// let p1 = hermite_h(1, x); // 2x
+/// let p2 = hermite_h(2, x); // 4x² - 2
+/// let p3 = hermite_h(3, x); // 8x³ - 12x
+/// assert_eq!(hermite_h_next(1, x, p1, p0), p2);
+/// assert_eq!(hermite_h_next(2, x, p2, p1), p3);
 /// ```
-#[allow(non_snake_case)]
 #[inline(always)]
-pub fn hermite_h_next(n: u32, x: f64, Hn: f64, Hn_prev: f64) -> f64 {
-    2.0 * (x * Hn - (n as f64) * Hn_prev)
+pub fn hermite_h_next(n: u32, x: f64, pn: f64, pn_prev: f64) -> f64 {
+    2.0 * hermite_he_next(n, x, pn, pn_prev)
+}
+
+/// Recurrence relation for [`hermite_he`]
+///
+/// *He<sub>n+1</sub>(x) = x He<sub>n</sub>(x) - n He<sub>n-1</sub>(x)*
+///
+/// # Examples
+///
+/// ```
+/// # use boost::math::{hermite_he, hermite_he_next};
+/// let x = 0.42;
+/// let p0 = hermite_he(0, x); // 1
+/// let p1 = hermite_he(1, x); // 2x
+/// let p2 = hermite_he(2, x); // 4x² - 2
+/// let p3 = hermite_he(3, x); // 8x³ - 12x
+/// assert_eq!(hermite_he_next(1, x, p1, p0), p2);
+/// assert_eq!(hermite_he_next(2, x, p2, p1), p3);
+/// ```
+#[inline(always)]
+pub fn hermite_he_next(n: u32, x: f64, pn: f64, pn_prev: f64) -> f64 {
+    x * pn - (n as f64) * pn_prev
 }
 
 /// Hermite Polynomial *H<sub>n</sub>(x)*
@@ -41,22 +61,57 @@ pub fn hermite_h(n: u32, x: f64) -> f64 {
     }
 }
 
+/// Monic Hermite Polynomial *He<sub>n</sub>(x)*
+///
+/// Note that this is the "probabilist's" Hermite polynomial, which is monic (leading coefficient
+/// is 1). It is related to the "physicist's" Hermite polynomial ([`hermite_h`]) by
+///
+/// *He<sub>n</sub>(x) = 2<sup>-n/2</sup> H<sub>n</sub>(x / √2)*
+///
+/// This function does not exist in the Boost Math C++ library.
+pub fn hermite_he(n: u32, x: f64) -> f64 {
+    let (mut p0, mut p1) = (1.0, x);
+    if n == 0 {
+        p0
+    } else {
+        for c in 1..n {
+            (p0, p1) = (p1, hermite_he_next(c, x, p1, p0));
+        }
+        p1
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::f64::consts::FRAC_1_SQRT_2;
 
-    const RTOL: f64 = 1e-14;
+    const ATOL: f64 = 1e-15;
+    const RTOL: f64 = 1e-12;
 
     fn hermite_h_ffi(n: u32, x: f64) -> f64 {
         unsafe { crate::ffi::math_hermite(n as core::ffi::c_uint, x) }
     }
 
     #[test]
-    fn test_hermite() {
+    fn test_hermite_h() {
         for n in 0..20 {
-            for x in -2..=2 {
+            for x in -10..=10 {
                 let x = x as f64 * 0.1;
-                assert_relative_eq!(hermite_h(n, x), hermite_h_ffi(n, x), max_relative = RTOL);
+                let h = hermite_h_ffi(n, x);
+                assert_relative_eq!(hermite_h(n, x), h, epsilon = ATOL, max_relative = RTOL);
+            }
+        }
+    }
+
+    #[test]
+    fn test_hermite_he() {
+        for n in 0..20 {
+            let c = FRAC_1_SQRT_2.powi(n as i32);
+            for x in -10..=10 {
+                let x = x as f64 * 0.1;
+                let h = c * hermite_h(n, FRAC_1_SQRT_2 * x);
+                assert_relative_eq!(hermite_he(n, x), h, epsilon = ATOL, max_relative = RTOL);
             }
         }
     }

--- a/src/math/special_functions/hermite.rs
+++ b/src/math/special_functions/hermite.rs
@@ -1,18 +1,5 @@
 //! boost/math/special_functions/hermite.hpp
 
-use crate::ffi;
-use core::ffi::c_uint;
-
-/// Hermite Polynomial *H<sub>n</sub>(x)*
-///
-/// Note that this is the  "physicist's" Hermite polynomial.
-///
-/// Corresponds to `boost::math::hermite(n, x)`.
-/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/hermite.html>
-pub fn hermite_h(n: u32, x: f64) -> f64 {
-    unsafe { ffi::math_hermite(n as c_uint, x) }
-}
-
 /// Recurrence relation for [`hermite_h`]
 ///
 /// *H<sub>n+1</sub>(x) = 2xH<sub>n</sub>(x) - 2nH<sub>n-1</sub>(x)*
@@ -35,16 +22,42 @@ pub fn hermite_h_next(n: u32, x: f64, Hn: f64, Hn_prev: f64) -> f64 {
     2.0 * (x * Hn - (n as f64) * Hn_prev)
 }
 
+/// Hermite Polynomial *H<sub>n</sub>(x)*
+///
+/// Note that this is the  "physicist's" Hermite polynomial.
+///
+/// This is a pure rust implementation equivalent to the `boost::math::hermite(n, x)` C++ function.
+/// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/hermite.html>
+pub fn hermite_h(n: u32, x: f64) -> f64 {
+    // Implement Hermite polynomials via recurrence:
+    let (mut p0, mut p1) = (1.0, 2.0 * x);
+    if n == 0 {
+        p0
+    } else {
+        for c in 1..n {
+            (p0, p1) = (p1, hermite_h_next(c, x, p1, p0));
+        }
+        p1
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const RTOL: f64 = 1e-14;
+
+    fn hermite_h_ffi(n: u32, x: f64) -> f64 {
+        unsafe { crate::ffi::math_hermite(n as core::ffi::c_uint, x) }
+    }
+
     #[test]
     fn test_hermite() {
-        assert_relative_eq!(hermite_h(0, 1.0), 1.0);
-        assert_relative_eq!(hermite_h(1, 1.0), 2.0);
-        assert_relative_eq!(hermite_h(2, 1.0), 2.0);
-        assert_relative_eq!(hermite_h(3, 1.0), -4.0);
-        assert_relative_eq!(hermite_h(4, 1.0), -20.0);
+        for n in 0..20 {
+            for x in -2..=2 {
+                let x = x as f64 * 0.1;
+                assert_relative_eq!(hermite_h(n, x), hermite_h_ffi(n, x), max_relative = RTOL);
+            }
+        }
     }
 }

--- a/src/math/special_functions/hermite.rs
+++ b/src/math/special_functions/hermite.rs
@@ -5,13 +5,15 @@ use core::ffi::c_uint;
 
 /// Hermite Polynomial *H<sub>n</sub>(x)*
 ///
+/// Note that this is the  "physicist's" Hermite polynomial.
+///
 /// Corresponds to `boost::math::hermite(n, x)`.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/hermite.html>
-pub fn hermite(n: u32, x: f64) -> f64 {
+pub fn hermite_h(n: u32, x: f64) -> f64 {
     unsafe { ffi::math_hermite(n as c_uint, x) }
 }
 
-/// Recurrence relation for [`hermite`]
+/// Recurrence relation for [`hermite_h`]
 ///
 /// *H<sub>n+1</sub>(x) = 2xH<sub>n</sub>(x) - 2nH<sub>n-1</sub>(x)*
 ///
@@ -24,13 +26,13 @@ pub fn hermite(n: u32, x: f64) -> f64 {
 /// let h1 = hermite(1, x); // 2x
 /// let h2 = hermite(2, x); // 4x² - 2
 /// let h3 = hermite(3, x); // 8x³ - 12x
-/// assert_eq!(hermite_next(1, &x, &h1, &h0), h2);
-/// assert_eq!(hermite_next(2, &x, &h2, &h1), h3);
+/// assert_eq!(hermite_next(1, x, h1, h0), h2);
+/// assert_eq!(hermite_next(2, x, h2, h1), h3);
 /// ```
 #[allow(non_snake_case)]
 #[inline(always)]
-pub fn hermite_next(n: u32, x: &f64, Hn: &f64, Hn_1: &f64) -> f64 {
-    2.0 * (x * Hn - (n as f64) * Hn_1)
+pub fn hermite_h_next(n: u32, x: f64, Hn: f64, Hn_prev: f64) -> f64 {
+    2.0 * (x * Hn - (n as f64) * Hn_prev)
 }
 
 #[cfg(test)]
@@ -39,10 +41,10 @@ mod tests {
 
     #[test]
     fn test_hermite() {
-        assert_relative_eq!(hermite(0, 1.0), 1.0);
-        assert_relative_eq!(hermite(1, 1.0), 2.0);
-        assert_relative_eq!(hermite(2, 1.0), 2.0);
-        assert_relative_eq!(hermite(3, 1.0), -4.0);
-        assert_relative_eq!(hermite(4, 1.0), -20.0);
+        assert_relative_eq!(hermite_h(0, 1.0), 1.0);
+        assert_relative_eq!(hermite_h(1, 1.0), 2.0);
+        assert_relative_eq!(hermite_h(2, 1.0), 2.0);
+        assert_relative_eq!(hermite_h(3, 1.0), -4.0);
+        assert_relative_eq!(hermite_h(4, 1.0), -20.0);
     }
 }

--- a/src/math/special_functions/jacobi.rs
+++ b/src/math/special_functions/jacobi.rs
@@ -3,10 +3,9 @@
 use crate::ffi;
 use core::ffi::c_uint;
 
-/// Jacobi Polynomial *P<sub>n</sub><sup>(α, β)</sup>(x)*
+/// Jacobi Polynomial *P<sub>n</sub><sup>(α,β)</sup>(x)*
 ///
-/// Corresponds to `boost::math::jacobi(n, alpha, beta, x)`.
-///
+/// Corresponds to `boost::math::jacobi(n, alpha, beta, x)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/jacobi.html>
 pub fn jacobi(n: u32, alpha: f64, beta: f64, x: f64) -> f64 {
     unsafe { ffi::math_jacobi(n as c_uint, alpha, beta, x) }
@@ -14,9 +13,10 @@ pub fn jacobi(n: u32, alpha: f64, beta: f64, x: f64) -> f64 {
 
 /// *k*-th derivative of [`jacobi`] with respect to `x`
 ///
-/// Corresponds to `boost::math::jacobi_derivative(n, alpha, beta, x, k)`.
-///
+/// Corresponds to `boost::math::jacobi_derivative(n, alpha, beta, x, k)` in C++.
 /// <https://boost.org/doc/libs/latest/libs/math/doc/html/math_toolkit/sf_poly/jacobi.html>
+#[doc(alias = "jacobi_prime")]
+#[doc(alias = "jacobi_double_prime")]
 pub fn jacobi_derivative(n: u32, alpha: f64, beta: f64, x: f64, k: u32) -> f64 {
     unsafe { ffi::math_jacobi_derivative(n as c_uint, alpha, beta, x, k as c_uint) }
 }

--- a/src/math/special_functions/laguerre.rs
+++ b/src/math/special_functions/laguerre.rs
@@ -37,18 +37,18 @@ pub fn laguerre_assoc(n: u32, m: u32, x: f64) -> f64 {
 /// let l1 = laguerre(1, x); // -x + 1
 /// let l2 = laguerre(2, x); // (x² - 4x + 2) / 2
 /// let l3 = laguerre(3, x); // (-x³ + 9x² - 18x + 6) / 6
-/// assert_relative_eq!(laguerre_next(1, &x, &l1, &l0), l2);
-/// assert_relative_eq!(laguerre_next(2, &x, &l2, &l1), l3);
+/// assert_relative_eq!(laguerre_next(1, x, l1, l0), l2);
+/// assert_relative_eq!(laguerre_next(2, x, l2, l1), l3);
 /// ```
 ///
 /// # See also
 ///
 /// - [`laguerre`]
 /// - [`laguerre_assoc_next`]
-#[allow(non_snake_case)]
 #[inline(always)]
-pub fn laguerre_next(n: u32, x: &f64, Ln: &f64, Ln_1: &f64) -> f64 {
-    laguerre_assoc_next(n, 0, x, Ln, Ln_1)
+#[allow(non_snake_case)]
+pub fn laguerre_next(n: u32, x: f64, Ln: f64, Ln_prev: f64) -> f64 {
+    laguerre_assoc_next(n, 0, x, Ln, Ln_prev)
 }
 
 /// Recurrence relation for [`laguerre_assoc`]
@@ -67,18 +67,18 @@ pub fn laguerre_next(n: u32, x: &f64, Ln: &f64, Ln_1: &f64) -> f64 {
 /// let l1 = laguerre_assoc(1, m, x);
 /// let l2 = laguerre_assoc(2, m, x);
 /// let l3 = laguerre_assoc(3, m, x);
-/// assert_relative_eq!(laguerre_assoc_next(1, m, &x, &l1, &l0), l2);
-/// assert_relative_eq!(laguerre_assoc_next(2, m, &x, &l2, &l1), l3);
+/// assert_relative_eq!(laguerre_assoc_next(1, m, x, l1, l0), l2);
+/// assert_relative_eq!(laguerre_assoc_next(2, m, x, l2, l1), l3);
 /// ```
 ///
 /// # See also
 ///
 /// - [`laguerre_assoc`]
 /// - [`laguerre_next`]
-#[allow(non_snake_case)]
 #[inline(always)]
-pub fn laguerre_assoc_next(n: u32, m: u32, x: &f64, Ln: &f64, Ln_1: &f64) -> f64 {
-    (((2 * n + m + 1) as f64 - x) * Ln - (n + m) as f64 * Ln_1) / (n + 1) as f64
+#[allow(non_snake_case)]
+pub fn laguerre_assoc_next(n: u32, m: u32, x: f64, Ln: f64, Ln_prev: f64) -> f64 {
+    (((2 * n + m + 1) as f64 - x) * Ln - (n + m) as f64 * Ln_prev) / (n + 1) as f64
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- more consistent function names and signatures
- reimplemented `hermite_h`  (previously `hermite`) in pure rust
- implemented new (rust-only) monic hermite polynomials (`hermite_he`, `hermite_he_next`)
- added rust-only functions for the general derivatives of (both kinds of) the hermite polynomials.